### PR TITLE
chore: Bump harper-core to 1.10 and fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       day: "monday"
       time: "07:00"
       timezone: "Europe/Berlin"
+    versioning-strategy: increase
     open-pull-requests-limit: 10
     commit-message:
       prefix: "deps(rust):"

--- a/GrammarEngine/Cargo.toml
+++ b/GrammarEngine/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["staticlib"]
 
 [dependencies]
-harper-core = "1.8"
+harper-core = "1.10"
 swift-bridge = "0.1.57"
 uuid = { version = "1.0", features = ["v4"] }
 whichlang = "0.1.0"

--- a/Sources/Positioning/Strategies/ElementTreeStrategy.swift
+++ b/Sources/Positioning/Strategies/ElementTreeStrategy.swift
@@ -88,7 +88,7 @@ class ElementTreeStrategy: GeometryProvider {
         // Designed for Chromium-based apps where other strategies fail
         // Note: Teams is NOT included here - its child elements have broken frame data
         // (child element frames don't match their visual position)
-        let targetApps: Set<String> = [
+        let targetApps: Set = [
             "notion.id",
             "com.notion.id",
             "com.google.Chrome",

--- a/Sources/Positioning/Strategies/OriginStrategy.swift
+++ b/Sources/Positioning/Strategies/OriginStrategy.swift
@@ -33,7 +33,7 @@ class OriginStrategy: GeometryProvider {
     func canHandle(element _: AXUIElement, bundleID: String) -> Bool {
         // Designed for Chromium/Electron apps that return zero dimensions
         // Note: Slack has its own dedicated SlackStrategy
-        let chromiumApps: Set<String> = [
+        let chromiumApps: Set = [
             "notion.id",
             "com.notion.id",
             "com.google.Chrome",

--- a/Sources/Utilities/ReadabilityCalculator.swift
+++ b/Sources/Utilities/ReadabilityCalculator.swift
@@ -12,14 +12,14 @@ import Foundation
 // MARK: - Types
 
 /// Readability algorithm types (expandable for future algorithms)
-enum ReadabilityAlgorithm: String, CaseIterable, Codable, Sendable {
+enum ReadabilityAlgorithm: String, CaseIterable, Codable {
     case fleschReadingEase
     // Future: fleschKincaidGrade, gunningFog, smog, colemanLiau, ari
 }
 
 /// Target audience level for readability scoring
 /// Each level has a minimum Flesch score threshold - text scoring below is considered too complex
-enum TargetAudience: String, CaseIterable, Codable, Sendable {
+enum TargetAudience: String, CaseIterable, Codable {
     case accessible // Everyone should understand (casual writing)
     case general // Average adult reader (default writing)
     case professional // Business readers
@@ -90,7 +90,7 @@ enum TargetAudience: String, CaseIterable, Codable, Sendable {
 }
 
 /// Result of a readability calculation
-struct ReadabilityResult: Sendable {
+struct ReadabilityResult {
     let score: Double
     let label: String
     let color: NSColor
@@ -133,7 +133,7 @@ struct ReadabilityResult: Sendable {
 }
 
 /// Result of readability analysis for a single sentence
-struct SentenceReadabilityResult: Sendable {
+struct SentenceReadabilityResult {
     let sentence: String
     let range: NSRange
     let score: Double
@@ -148,7 +148,7 @@ struct SentenceReadabilityResult: Sendable {
 }
 
 /// Full readability analysis including per-sentence breakdown
-struct TextReadabilityAnalysis: Sendable {
+struct TextReadabilityAnalysis {
     let overallResult: ReadabilityResult
     let sentenceResults: [SentenceReadabilityResult]
     let targetAudience: TargetAudience

--- a/Tests/Unit/AppBehaviorRegressionTests.swift
+++ b/Tests/Unit/AppBehaviorRegressionTests.swift
@@ -135,18 +135,18 @@ final class AppBehaviorRegressionTests: XCTestCase {
     /// Valid reasons: Mac Catalyst, WebKit compose view, or documented UTF-16 AX API usage
     func testNativeAppsWithoutWebKitUseGrapheme() {
         // Apps that are known to be native but use WebKit internally
-        let webKitNativeApps: Set<String> = [
+        let webKitNativeApps: Set = [
             "com.apple.mail", // Uses WebKit for compose
         ]
 
         // Mac Catalyst apps (use UTF-16 but aren't "web-based" in the Electron sense)
-        let catalystApps: Set<String> = [
+        let catalystApps: Set = [
             "com.apple.MobileSMS", // Messages
             "net.whatsapp.WhatsApp", // WhatsApp
         ]
 
         // Native apps that use UTF-16 for AX APIs (documented in behavior file)
-        let nativeWithUTF16AX: Set<String> = [
+        let nativeWithUTF16AX: Set = [
             "ru.keepcoder.Telegram", // Uses UTF-16 for AXNumberOfCharacters
         ]
 


### PR DESCRIPTION
## Summary
- Bump `harper-core` from 1.8 to 1.10 ([release notes](https://github.com/Automattic/harper/releases/tag/v1.10.0))
- Fix dependabot not creating PRs for Cargo minor version updates by adding `versioning-strategy: increase` — the default `auto` strategy skipped PRs when new versions fell within the existing `^1.8` semver range
- Fix pre-existing SwiftFormat lint warnings (redundantSendable, redundantType)

## Why dependabot missed harper-core 1.9 and 1.10
`Cargo.toml` specified `harper-core = "1.8"` which in Cargo means `^1.8` (`>=1.8.0, <2.0.0`). Both 1.9.0 and 1.10.0 fall within this range, so dependabot's default `auto` versioning strategy saw no manifest change needed and didn't open PRs. The `increase` strategy forces it to always bump the version specifier.

## Test plan
- [x] Rust build passes
- [x] All 137 Rust tests pass
- [x] Clippy clean
- [x] SwiftFormat clean