### PR TITLE
feat: Add copy-to-clipboard fallback UI for grammar error popovers

### DIFF
--- a/Sources/App/AnalysisCoordinator+TextReplacement.swift
+++ b/Sources/App/AnalysisCoordinator+TextReplacement.swift
@@ -2490,12 +2490,9 @@ extension AnalysisCoordinator {
         switch selectionResult {
         case .failedRootOnlyUnreliable:
             // Text contains mentions/links that prevent reliable automatic replacement
-            // Copy to clipboard and show warning so user can paste manually
-            Logger.info("Grammar replacement: Root-only selection unreliable - copying to clipboard for manual paste", category: Logger.analysis)
-            let pasteboard = NSPasteboard.general
-            pasteboard.clearContents()
-            pasteboard.setString(suggestion, forType: .string)
-            SuggestionPopover.shared.showStatusMessage("Copied to clipboard - paste manually (⌘V)")
+            // Show copy fallback UI so user can manually copy and paste
+            Logger.info("Grammar replacement: Root-only selection unreliable - showing copy fallback UI", category: Logger.analysis)
+            SuggestionPopover.shared.showCopyFallback(textToCopy: suggestion)
             return
 
         case .failed:

--- a/Sources/UI/PopoverContentViews.swift
+++ b/Sources/UI/PopoverContentViews.swift
@@ -865,9 +865,77 @@ struct PopoverContentView: View {
                     .padding(.bottom, 6)
                 }
 
+                // Warning banner when automatic replacement isn't possible
+                if popover.showingCopyFallback {
+                    HStack(spacing: 8) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundColor(.orange)
+                            .font(.system(size: baseTextSize * 0.9))
+
+                        Text("Auto-replace unavailable for text with mentions. Copy and paste manually.")
+                            .font(.system(size: baseTextSize * 0.8))
+                            .foregroundColor(colors.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.orange.opacity(0.1))
+                }
+
                 // Content area
                 VStack(alignment: .leading, spacing: 2) {
-                    if isAIRephrase {
+                    if popover.showingCopyFallback {
+                        // Copy fallback mode - show suggestion text (non-interactive) and Copy/Skip buttons
+                        if let fallbackText = popover.copyFallbackText {
+                            Text(fallbackText)
+                                .font(.system(size: bodyTextSize, weight: .medium))
+                                .foregroundColor(colors.textPrimary)
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 4)
+                        }
+
+                        HStack(spacing: 8) {
+                            Button(action: { popover.performCopyFallback() }) {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "doc.on.doc")
+                                        .font(.system(size: 11, weight: .semibold))
+                                    Text("Copy")
+                                        .font(.system(size: baseTextSize * 0.9, weight: .medium))
+                                }
+                                .foregroundColor(colors.link)
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 5)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 6)
+                                        .fill(colors.link.opacity(0.12))
+                                )
+                            }
+                            .buttonStyle(.plain)
+                            .fixedSize()
+                            .help("Copy suggestion to clipboard")
+                            .accessibilityLabel("Copy to clipboard")
+
+                            Button(action: { popover.cancelCopyFallback() }) {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "forward")
+                                        .font(.system(size: 11, weight: .medium))
+                                    Text("Skip")
+                                        .font(.system(size: baseTextSize * 0.9, weight: .medium))
+                                }
+                                .foregroundColor(colors.textSecondary)
+                            }
+                            .buttonStyle(.plain)
+                            .fixedSize()
+                            .help("Skip this suggestion")
+                            .accessibilityLabel("Skip suggestion")
+
+                            Spacer()
+                        }
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 4)
+
+                    } else if isAIRephrase {
                         // AI rephrase - show before/after
                         let originalText = validSuggestions[0]
                         let rephraseText = validSuggestions[1]
@@ -1054,8 +1122,8 @@ struct PopoverContentView: View {
                     )
             }
         )
-        // Width: 400 for indicator with sentence context (match style popover), 300 for AI rephrase, 220 for inline
-        .frame(width: popover.openedFromIndicator && !popover.sourceText.isEmpty ? 400 : (isAIRephraseError ? 300 : 220))
+        // Width: 400 for indicator with sentence context (match style popover), 300 for AI rephrase/copy fallback, 220 for inline
+        .frame(width: popover.openedFromIndicator && !popover.sourceText.isEmpty ? 400 : (isAIRephraseError || popover.showingCopyFallback ? 300 : 220))
         .fixedSize(horizontal: false, vertical: true)
         .colorScheme(effectiveColorScheme)
         .accessibilityElement(children: .contain)

--- a/Sources/UI/SuggestionPopover.swift
+++ b/Sources/UI/SuggestionPopover.swift
@@ -244,6 +244,8 @@ class SuggestionPopover: NSObject, ObservableObject {
         openedFromIndicator = false
 
         mode = .grammarError
+        showingCopyFallback = false
+        copyFallbackText = nil
         self.allErrors = allErrors
         self.sourceText = sourceText
 
@@ -278,6 +280,8 @@ class SuggestionPopover: NSObject, ObservableObject {
         openedFromIndicator = false
 
         mode = .styleSuggestion
+        showingCopyFallback = false
+        copyFallbackText = nil
         currentStyleSuggestion = suggestion
         allStyleSuggestions = allSuggestions
         currentStyleIndex = allSuggestions.firstIndex(where: { $0.id == suggestion.id }) ?? 0
@@ -845,42 +849,51 @@ class SuggestionPopover: NSObject, ObservableObject {
         }
     }
 
-    /// Copy the fallback text to clipboard and move to next suggestion
+    /// Copy the fallback text to clipboard and move to next item
     func performCopyFallback() {
         guard let text = copyFallbackText else { return }
-        let suggestion = currentStyleSuggestion
 
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(text, forType: .string)
 
-        Logger.info("Popover: Copied text to clipboard (\(text.count) chars)", category: Logger.ui)
+        Logger.info("Popover: Copied text to clipboard (\(text.count) chars, mode: \(mode))", category: Logger.ui)
 
         // Reset fallback state
         showingCopyFallback = false
         copyFallbackText = nil
 
-        // Notify coordinator to remove from tracking
-        if let suggestion {
-            onCopyFallbackComplete?(suggestion)
-        }
+        switch mode {
+        case .grammarError:
+            // Dismiss the current error and move to next
+            dismissError()
 
-        moveToNextStyleSuggestion()
+        case .styleSuggestion:
+            // Notify coordinator to remove from tracking
+            if let suggestion = currentStyleSuggestion {
+                onCopyFallbackComplete?(suggestion)
+            }
+            moveToNextStyleSuggestion()
+        }
     }
 
-    /// Cancel the copy fallback and move to next suggestion without copying
+    /// Cancel the copy fallback and move to next item without copying
     func cancelCopyFallback() {
-        let suggestion = currentStyleSuggestion
-
         showingCopyFallback = false
         copyFallbackText = nil
 
-        // Notify coordinator to remove from tracking
-        if let suggestion {
-            onCopyFallbackComplete?(suggestion)
-        }
+        switch mode {
+        case .grammarError:
+            // Dismiss the current error and move to next
+            dismissError()
 
-        moveToNextStyleSuggestion()
+        case .styleSuggestion:
+            // Notify coordinator to remove from tracking
+            if let suggestion = currentStyleSuggestion {
+                onCopyFallbackComplete?(suggestion)
+            }
+            moveToNextStyleSuggestion()
+        }
     }
 
     // MARK: - Error Synchronization


### PR DESCRIPTION
When grammar fixes can't be auto-applied (e.g., text with mentions in Slack), show the same Copy/Skip fallback UI that style suggestions already use, instead of silently copying to clipboard with a brief status message.