### PR TITLE
Release v0.2.0-rc.1

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.0</string>
+	<string>0.2.0-rc.1</string>
 	<key>CFBundleVersion</key>
-	<string>25</string>
+	<string>26</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>

--- a/appcast.xml
+++ b/appcast.xml
@@ -3,6 +3,25 @@
     <channel>
         <title>TextWarden Releases</title>
         <item>
+            <title>0.2.0-rc.1</title>
+            <pubDate>Mon, 16 Mar 2026 21:25:44 +0100</pubDate>
+            <sparkle:version>26</sparkle:version>
+            <sparkle:shortVersionString>0.2.0-rc.1</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+            <sparkle:channel>experimental</sparkle:channel>
+            <description>&lt;h3&gt;What&amp;#x27;s Changed&lt;/h3&gt;
+&lt;ul&gt;
+&lt;li&gt;feat: Add copy-to-clipboard fallback UI for grammar error popovers (&lt;a href=&quot;https://github.com/PhilipSchmid/textwarden/commit/2dd810a&quot;&gt;&lt;code&gt;2dd810a&lt;/code&gt;&lt;/a&gt;) by @PhilipSchmid&lt;/li&gt;
+&lt;li&gt;&quot;Claude Code Review workflow&quot; (&lt;a href=&quot;https://github.com/PhilipSchmid/textwarden/commit/f929a63&quot;&gt;&lt;code&gt;f929a63&lt;/code&gt;&lt;/a&gt;) by @PhilipSchmid&lt;/li&gt;
+&lt;li&gt;&quot;Claude PR Assistant workflow&quot; (&lt;a href=&quot;https://github.com/PhilipSchmid/textwarden/commit/4a78ee2&quot;&gt;&lt;code&gt;4a78ee2&lt;/code&gt;&lt;/a&gt;) by @PhilipSchmid&lt;/li&gt;
+&lt;li&gt;style: Fix redundantSendable and redundantType lint warnings (&lt;a href=&quot;https://github.com/PhilipSchmid/textwarden/commit/e21805b&quot;&gt;&lt;code&gt;e21805b&lt;/code&gt;&lt;/a&gt;) by @PhilipSchmid&lt;/li&gt;
+&lt;li&gt;ci: Use increase versioning strategy for Cargo dependabot (&lt;a href=&quot;https://github.com/PhilipSchmid/textwarden/commit/6cfb495&quot;&gt;&lt;code&gt;6cfb495&lt;/code&gt;&lt;/a&gt;) by @PhilipSchmid&lt;/li&gt;
+&lt;li&gt;chore: Bump harper-core from 1.8 to 1.10 (&lt;a href=&quot;https://github.com/PhilipSchmid/textwarden/commit/42dcbf2&quot;&gt;&lt;code&gt;42dcbf2&lt;/code&gt;&lt;/a&gt;) by @PhilipSchmid&lt;/li&gt;
+&lt;li&gt;chore: Enforce PR-based workflow and commit signing (&lt;a href=&quot;https://github.com/PhilipSchmid/textwarden/commit/cd5c023&quot;&gt;&lt;code&gt;cd5c023&lt;/code&gt;&lt;/a&gt;) by @PhilipSchmid&lt;/li&gt;
+&lt;/ul&gt;</description>
+            <enclosure url="https://github.com/PhilipSchmid/textwarden/releases/download/v0.2.0-rc.1/TextWarden-0.2.0-rc.1-Universal.dmg" length="31255705" type="application/octet-stream" sparkle:edSignature="pdWeoCW/ZqHCbgM4U/umg921SG3O2BOi22ek7Jfgqj3pjeZ9znfvW2RNjxzicG0geMYEZhqIbBHLyrFZFYoaDw=="/>
+        </item>
+        <item>
             <title>0.1.0</title>
             <pubDate>Fri, 20 Feb 2026 19:14:57 +0100</pubDate>
             <sparkle:version>25</sparkle:version>


### PR DESCRIPTION
Release v0.2.0-rc.1

## Changes since v0.1.0
- feat: Add copy-to-clipboard fallback UI for grammar error popovers
- style: Fix redundantSendable and redundantType lint warnings
- ci: Use increase versioning strategy for Cargo dependabot
- ci: Claude Code Review and PR Assistant workflows
- chore: Bump harper-core from 1.8 to 1.10
- chore: Enforce PR-based workflow and commit signing