### PR TITLE
chore: Bump harper-core from 1.10 to 2.0

### DIFF
--- a/GrammarEngine/Cargo.toml
+++ b/GrammarEngine/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["staticlib"]
 
 [dependencies]
-harper-core = "1.10"
+harper-core = "2.0"
 swift-bridge = "0.1.57"
 uuid = { version = "1.0", features = ["v4"] }
 whichlang = "0.1.0"


### PR DESCRIPTION
## Summary

- Upgrade harper-core grammar engine from 1.10 to 2.0
- Adds ~20 new grammar rules (ArriveTo, AspireTo, WereWhere, etc.)
- No code changes required — all existing APIs unchanged
- All Rust and Swift tests pass

Release notes: https://github.com/Automattic/harper/releases/tag/v2.0.0