### PR TITLE
chore: Bump harper-core to 2.3.1 and other dependencies

### DIFF
--- a/GrammarEngine/Cargo.toml
+++ b/GrammarEngine/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 crate-type = ["staticlib"]
 
 [dependencies]
-harper-core = "2.0"
-swift-bridge = "0.1.57"
+harper-core = { git = "https://github.com/Automattic/harper", tag = "v2.3.1" }
+swift-bridge = "0.1.59"
 uuid = { version = "1.0", features = ["v4"] }
 whichlang = "0.1.0"
 tracing = "0.1"
@@ -19,7 +19,7 @@ serde_json = "1.0"
 directories = "6.0"
 
 [build-dependencies]
-swift-bridge-build = "0.1.57"
+swift-bridge-build = "0.1.59"
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }


### PR DESCRIPTION
## Summary

Bumps TextWarden dependencies to their latest versions, headlined by [harper v2.3.1](https://github.com/Automattic/harper/releases/tag/v2.3.1).

### Rust (`GrammarEngine/Cargo.toml`)
- `harper-core` 2.0 → **2.3.1** (via git tag — 2.3.1 is not yet published to crates.io, which still maxes at 2.0.0)
- `sysinfo` 0.38 → 0.39
- `swift-bridge` / `swift-bridge-build` 0.1.57 → 0.1.59

### Swift packages
`Package.resolved` is gitignored, so these re-resolve to latest within their existing `upToNextMajor` bounds on build:
- STTextView 2.3.5 → 2.3.10
- Sparkle 2.9.0 → 2.9.2
- swift-markdown 0.7.3 → 0.8.0 (cmark-gfm 0.7.1 → 0.8.0)
- ConfettiSwiftUI left at 2.0.3 (3.0.0 is a major bump, out of range)

### Toolchain
harper-core 2.3.1 requires **Rust ≥ 1.96** to compile (1.94 hits a type-inference error in harper's own source).

## Validation
- ✅ Rust: 137 tests pass
- ✅ Swift: all tests pass
- ✅ `make ci-check` (fmt, clippy, lint, build) clean
- ✅ App builds (universal arm64+x86_64) and launches without errors