### PR TITLE
fix: Skip Dock backdrop in modal dialog detection

### DIFF
--- a/Sources/UI/PopoverUtilities.swift
+++ b/Sources/UI/PopoverUtilities.swift
@@ -135,7 +135,11 @@ enum ModalDialogDetector {
             if ownerName == "TextWarden" { continue }
 
             // Skip system UI (menu bar, status items, etc.)
-            if ownerName == "Window Server" || ownerName == "SystemUIServer" { continue }
+            // - Window Server: menu bar, cursor, transition effects
+            // - SystemUIServer: status menu items
+            // - Dock: kCGDockWindowLevel (20) backdrop can span the full screen on
+            //   macOS Tahoe and is never a modal dialog (issue #66)
+            if ownerName == "Window Server" || ownerName == "SystemUIServer" || ownerName == "Dock" { continue }
 
             // Skip apps with persistent high-level overlays that are always present
             // unlike modal dialogs which only appear during user interaction
@@ -154,6 +158,11 @@ enum ModalDialogDetector {
                 height: height
             )
 
+            // Skip windows that cover most of a display: real modal dialogs are
+            // bounded panels, not full-screen backdrops. This catches invisible
+            // overlays from system processes we don't enumerate by name.
+            if isFullScreenBackdrop(windowFrame) { continue }
+
             // Check if mouse is inside this window
             if windowFrame.contains(mouseLocation) {
                 Logger.debug("ModalDialogDetector: Detected modal-level window '\(ownerName)' (level \(windowLevel)) at \(windowFrame) containing mouse at \(mouseLocation)", category: Logger.ui)
@@ -161,6 +170,22 @@ enum ModalDialogDetector {
             }
         }
 
+        return false
+    }
+
+    /// True when a window covers ≥80% of any connected display in both dimensions.
+    /// Real modal dialogs are bounded panels; backdrops span the full screen.
+    private static func isFullScreenBackdrop(_ windowFrame: CGRect) -> Bool {
+        let coverageThreshold: CGFloat = 0.80
+        for screen in NSScreen.screens {
+            let screenFrame = screen.frame
+            guard screenFrame.width > 0, screenFrame.height > 0 else { continue }
+            let widthRatio = windowFrame.width / screenFrame.width
+            let heightRatio = windowFrame.height / screenFrame.height
+            if widthRatio >= coverageThreshold, heightRatio >= coverageThreshold {
+                return true
+            }
+        }
         return false
     }
 }


### PR DESCRIPTION
## Summary
- `ModalDialogDetector.isMouseOverModalWindow()` filters CGWindow list by `windowLevel > floatingLevel` (>3), which catches the Dock's invisible backdrop window at `kCGDockWindowLevel` (20). On macOS Tahoe this backdrop can span the full screen, so the cursor is always inside it and every left-click on the capsule is suppressed by `isModalDialogPresent() → true`. Right-click is unaffected because it goes through a different path.
- Adds `"Dock"` to the owner skip list and short-circuits any window covering ≥80% of a display in both dimensions — real modal dialogs are bounded panels, not full-screen backdrops. The size heuristic future-proofs against other system processes shipping similar invisible overlays.

Fixes #66

## Test plan
- [ ] `make ci-check` — Rust fmt/clippy/tests, Swift fmt, SwiftLint, build all pass
- [ ] On a system that reproduces the bug (Dock backdrop appears in `CGWindowListCopyWindowInfo`), left-clicking the capsule opens the suggestion popover
- [ ] System modal dialogs (Print, Save) still correctly suppress the popover (popover does not appear on top of a real modal)
- [ ] Capsule still opens normally with the Dock in default, auto-hide, and magnified configurations