### PR TITLE
Release v0.3.1-beta.1

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.0</string>
+	<string>0.3.1-beta.1</string>
 	<key>CFBundleVersion</key>
-	<string>28</string>
+	<string>29</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>

--- a/appcast.xml
+++ b/appcast.xml
@@ -3,6 +3,19 @@
     <channel>
         <title>TextWarden Releases</title>
         <item>
+            <title>0.3.1-beta.1</title>
+            <pubDate>Sat, 06 Jun 2026 10:40:27 +0200</pubDate>
+            <sparkle:version>29</sparkle:version>
+            <sparkle:shortVersionString>0.3.1-beta.1</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+            <sparkle:channel>experimental</sparkle:channel>
+            <description>&lt;h3&gt;What&amp;#x27;s Changed&lt;/h3&gt;
+&lt;ul&gt;
+&lt;li&gt;fix: Skip Dock backdrop in modal dialog detection (&lt;a href="https://github.com/PhilipSchmid/textwarden/commit/e6def7e"&gt;&lt;code&gt;e6def7e&lt;/code&gt;&lt;/a&gt;) by @PhilipSchmid&lt;/li&gt;
+&lt;/ul&gt;</description>
+            <enclosure url="https://github.com/PhilipSchmid/textwarden/releases/download/v0.3.1-beta.1/TextWarden-0.3.1-beta.1-Universal.dmg" length="31625421" type="application/octet-stream" sparkle:edSignature="+vJ/+NbFQAlp9p523rAiMoSr2oNzijv66Z5xBlxXAQLO+fgnl87fQlEKQO5P1Lqoc7KgQ3MRkn9fdhYOJjRZBg=="/>
+        </item>
+        <item>
             <title>0.3.0</title>
             <pubDate>Mon, 01 Jun 2026 12:06:53 +0200</pubDate>
             <sparkle:version>28</sparkle:version>


### PR DESCRIPTION
## Summary
- Bumps to **v0.3.1-beta.1** (build 29), updates `appcast.xml` (experimental channel)
- Single fix on top of v0.3.0: #67 — Skip Dock backdrop in modal-dialog detection (fixes #66)

## Test plan
- [ ] Beta tester (#66 reporter) confirms left-clicking the capsule opens the suggestion popover with Dock backdrop visible
- [ ] System modal dialogs (Print, Save) still correctly suppress the popover
- [ ] Sparkle appcast loads cleanly on experimental channel