### PR TITLE
fix: clear v0.3.2 release blockers

### DIFF
--- a/GrammarEngine/Cargo.lock
+++ b/GrammarEngine/Cargo.lock
@@ -3668,9 +3668,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/GrammarEngine/Cargo.lock
+++ b/GrammarEngine/Cargo.lock
@@ -716,6 +716,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,6 +929,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -2172,11 +2192,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2186,10 +2204,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3668,14 +3689,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash 2.1.2",
  "rustls",
@@ -3743,6 +3765,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3771,6 +3804,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_distr"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3778,6 +3817,15 @@ checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand 0.9.4",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4202,7 +4250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -234,16 +234,23 @@ build_archive() {
     local archive_path="$RELEASE_DIR/$APP_NAME.xcarchive"
     echo -e "${BLUE}Creating Xcode archive...${NC}" >&2
 
+    # Never allow a failed archive command to fall back to a previous release.
+    rm -rf "$archive_path"
+
     # Run xcodebuild in subshell with clean environment
-    (
+    if ! (
         cd "$PROJECT_ROOT"
         xcodebuild archive \
             -project "$PROJECT" \
             -scheme "$SCHEME" \
             -configuration Release \
+            -destination 'generic/platform=macOS' \
             -archivePath "$archive_path" \
-            2>&1 | grep -E "(error:|warning:|ARCHIVE SUCCEEDED|ARCHIVE FAILED)" || true
-    ) >&2
+            2>&1 | grep -E "(error:|warning:|ARCHIVE SUCCEEDED|ARCHIVE FAILED)"
+    ) >&2; then
+        echo -e "${RED}Archive command failed${NC}" >&2
+        exit 1
+    fi
 
     # Verify archive succeeded
     if [[ ! -d "$archive_path" ]]; then
@@ -254,6 +261,15 @@ build_archive() {
     # Verify the app exists in the archive
     if [[ ! -d "$archive_path/Products/Applications/$APP_NAME.app" ]]; then
         echo -e "${RED}Archive created but app bundle not found${NC}" >&2
+        exit 1
+    fi
+
+    # Confirm the archive is the release requested in this run.
+    local archived_info="$archive_path/Products/Applications/$APP_NAME.app/Contents/Info.plist"
+    local archived_version=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$archived_info")
+    local archived_build=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$archived_info")
+    if [[ "$archived_version" != "$(get_version)" || "$archived_build" != "$(get_build)" ]]; then
+        echo -e "${RED}Archive version does not match Info.plist${NC}" >&2
         exit 1
     fi
 
@@ -294,6 +310,7 @@ export_app() {
 # Notarize the app
 notarize_app() {
     local dmg_path="$1"
+    local required="${2:-false}"
 
     echo -e "${BLUE}Notarizing app...${NC}"
 
@@ -302,9 +319,16 @@ notarize_app() {
         echo -e "${YELLOW}APPLE_ID not set. Checking keychain for notarytool credentials...${NC}"
         # Try using stored keychain profile
         if ! xcrun notarytool history --keychain-profile "TextWarden" >/dev/null 2>&1; then
-            echo -e "${YELLOW}No keychain profile found. Skipping notarization.${NC}"
-            echo -e "${YELLOW}To enable notarization, run:${NC}"
+            if [[ "$required" == "true" ]]; then
+                echo -e "${RED}No keychain profile found. Production releases require notarization.${NC}"
+            else
+                echo -e "${YELLOW}No keychain profile found. Skipping notarization.${NC}"
+            fi
+            echo -e "${YELLOW}Configure notarization with:${NC}"
             echo -e "  xcrun notarytool store-credentials \"TextWarden\" --apple-id YOUR_APPLE_ID --team-id $TEAM_ID"
+            if [[ "$required" == "true" ]]; then
+                return 1
+            fi
             return 0
         fi
         local auth_args="--keychain-profile TextWarden"
@@ -327,7 +351,10 @@ notarize_app() {
     else
         echo -e "${RED}Notarization failed:${NC}"
         echo "$result"
-        echo -e "${YELLOW}Continuing without notarization...${NC}"
+        if [[ "$required" == "true" ]]; then
+            return 1
+        fi
+        echo -e "${YELLOW}Continuing prerelease without notarization...${NC}"
     fi
 }
 
@@ -644,9 +671,11 @@ do_release() {
 
     local version_type=$(parse_version_type "$version")
     local is_prerelease="false"
+    local notarization_required="true"
 
     if [[ "$version_type" != "release" ]]; then
         is_prerelease="true"
+        notarization_required="false"
     fi
 
     echo ""
@@ -678,7 +707,7 @@ do_release() {
     mkdir -p "$RELEASE_DIR"
 
     # Get last tag for release notes
-    local last_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+    local last_tag=$(git tag --sort=-creatordate | grep -v "^v$version$" | head -1)
 
     # Ensure all commits are pushed before generating release notes
     # This allows GitHub API to look up the proper @username for each commit
@@ -719,7 +748,7 @@ do_release() {
     local dmg_path=$(create_dmg "$app_path" "$version")
 
     # Notarize the DMG FIRST (stapling modifies the DMG)
-    notarize_app "$dmg_path"
+    notarize_app "$dmg_path" "$notarization_required"
 
     # Sign with Sparkle AFTER stapling (signature must be for final DMG)
     local signature=$(sign_update "$dmg_path" "$sparkle_bin")

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -730,7 +730,7 @@ do_release() {
     # Commit version changes
     echo -e "${BLUE}Committing version changes...${NC}"
     git add "$PROJECT_ROOT/Info.plist" "$PROJECT_ROOT/appcast.xml"
-    git commit -s -S -m "Release v$version"
+    git commit -s -S -m "chore: release v$version"
 
     # Create git tag
     git tag -a "v$version" -m "Release v$version"


### PR DESCRIPTION
## Summary

- update `quinn-proto` to 0.11.15 for GHSA-4w2j-m93h-cj5j
- require a fresh macOS archive and verify its version before packaging
- require notarization for stable releases
- generate notes from the latest created tag after rebase merges
- keep automated release commits in Conventional Commit format

## Validation

- `make run`
- `make ci-check`
- production release dry run created and signed a fresh macOS 0.3.2 build 31 archive, then stopped at the missing notarization profile without creating a commit or tag