### PR TITLE
Fix stale grammar results and Unicode indexing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
             -only-testing:TextWardenTests/AppBehaviorRegistryTests \
             -only-testing:TextWardenTests/AppBehaviorRegressionTests \
             -only-testing:TextWardenTests/ApplicationConfigurationTests \
+            -only-testing:TextWardenTests/GrammarAnalysisRequestTests \
             -only-testing:TextWardenTests/GrammarEngineFFITests \
             -only-testing:TextWardenTests/PerformanceProfilerTests \
             -only-testing:TextWardenTests/ReadabilityTests \
@@ -100,6 +101,7 @@ jobs:
             -only-testing:TextWardenTests/SlackStrategyValidationTests \
             -only-testing:TextWardenTests/SuggestionPopoverTests \
             -only-testing:TextWardenTests/TextMonitorTests \
+            -only-testing:TextWardenTests/TextIndexConverterTests \
             -only-testing:TextWardenTests/UnderlineStateManagerTests \
             -only-testing:TextWardenTests/UserStatisticsTests \
             -only-testing:TextWardenTests/VirtualKeyCodeTests \

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ test-swift: ## Run Swift tests (unit tests only, excludes performance benchmarks
 		-only-testing:TextWardenTests/AppBehaviorRegistryTests \
 		-only-testing:TextWardenTests/AppBehaviorRegressionTests \
 		-only-testing:TextWardenTests/ApplicationConfigurationTests \
+		-only-testing:TextWardenTests/GrammarAnalysisRequestTests \
 		-only-testing:TextWardenTests/GrammarEngineFFITests \
 		-only-testing:TextWardenTests/PerformanceProfilerTests \
 		-only-testing:TextWardenTests/ReadabilityTests \
@@ -105,6 +106,7 @@ test-swift: ## Run Swift tests (unit tests only, excludes performance benchmarks
 		-only-testing:TextWardenTests/SlackStrategyValidationTests \
 		-only-testing:TextWardenTests/SuggestionPopoverTests \
 		-only-testing:TextWardenTests/TextMonitorTests \
+		-only-testing:TextWardenTests/TextIndexConverterTests \
 		-only-testing:TextWardenTests/UnderlineStateManagerTests \
 		-only-testing:TextWardenTests/UserStatisticsTests \
 		-only-testing:TextWardenTests/VirtualKeyCodeTests \
@@ -173,6 +175,7 @@ ci-check: ## Run CI checks locally (use before pushing)
 		-only-testing:TextWardenTests/AppBehaviorRegistryTests \
 		-only-testing:TextWardenTests/AppBehaviorRegressionTests \
 		-only-testing:TextWardenTests/ApplicationConfigurationTests \
+		-only-testing:TextWardenTests/GrammarAnalysisRequestTests \
 		-only-testing:TextWardenTests/GrammarEngineFFITests \
 		-only-testing:TextWardenTests/PerformanceProfilerTests \
 		-only-testing:TextWardenTests/ReadabilityTests \
@@ -180,6 +183,7 @@ ci-check: ## Run CI checks locally (use before pushing)
 		-only-testing:TextWardenTests/SlackStrategyValidationTests \
 		-only-testing:TextWardenTests/SuggestionPopoverTests \
 		-only-testing:TextWardenTests/TextMonitorTests \
+		-only-testing:TextWardenTests/TextIndexConverterTests \
 		-only-testing:TextWardenTests/UnderlineStateManagerTests \
 		-only-testing:TextWardenTests/UserStatisticsTests \
 		-only-testing:TextWardenTests/VirtualKeyCodeTests \

--- a/Sources/App/AnalysisCoordinator+GrammarAnalysis.swift
+++ b/Sources/App/AnalysisCoordinator+GrammarAnalysis.swift
@@ -10,6 +10,40 @@ import AppKit
 @preconcurrency import ApplicationServices
 import Foundation
 
+/// Immutable identity for one background grammar request.
+///
+/// AXUIElement is safe to retain for the lifetime of the request. The value is only compared
+/// on the main actor after analysis completes; grammar work never accesses it off-main.
+struct GrammarAnalysisRequest: @unchecked Sendable {
+    let generation: UInt64
+    let sourceText: String
+    let context: ApplicationContext
+    let element: AXUIElement?
+
+    func matches(
+        currentGeneration: UInt64,
+        currentText: String?,
+        currentContext: ApplicationContext?,
+        currentElement: AXUIElement?
+    ) -> Bool {
+        guard generation == currentGeneration,
+              sourceText == currentText,
+              context == currentContext
+        else {
+            return false
+        }
+
+        switch (element, currentElement) {
+        case (nil, nil):
+            return true
+        case let (expected?, current?):
+            return CFEqual(expected, current)
+        default:
+            return false
+        }
+    }
+}
+
 // MARK: - Grammar Analysis
 
 extension AnalysisCoordinator {
@@ -48,6 +82,36 @@ extension AnalysisCoordinator {
             checkEllipsis: userPreferences.checkEllipsis,
             checkUnclosedQuotes: userPreferences.checkUnclosedQuotes,
             checkDashes: userPreferences.checkDashes
+        )
+    }
+
+    /// Invalidate any grammar result that has not reached the main actor yet.
+    func invalidateGrammarAnalysis() {
+        grammarAnalysisGeneration &+= 1
+    }
+
+    /// Create an identity token for a newly dispatched grammar request.
+    private func beginGrammarAnalysis(
+        text: String,
+        context: ApplicationContext,
+        element: AXUIElement?
+    ) -> GrammarAnalysisRequest {
+        grammarAnalysisGeneration &+= 1
+        return GrammarAnalysisRequest(
+            generation: grammarAnalysisGeneration,
+            sourceText: text,
+            context: context,
+            element: element
+        )
+    }
+
+    /// Check all mutable inputs that could make a completed result stale.
+    private func isCurrentGrammarAnalysis(_ request: GrammarAnalysisRequest) -> Bool {
+        request.matches(
+            currentGeneration: grammarAnalysisGeneration,
+            currentText: currentSegment?.content,
+            currentContext: monitoredContext,
+            currentElement: textMonitor.monitoredElement
         )
     }
 
@@ -116,6 +180,11 @@ extension AnalysisCoordinator {
         // CRITICAL: Capture the monitored element BEFORE async operation
         let capturedElement = textMonitor.monitoredElement
         let segmentContent = segment.content
+        let request = beginGrammarAnalysis(
+            text: segmentContent,
+            context: segment.context,
+            element: capturedElement
+        )
 
         // Capture UserPreferences values on main thread before async dispatch
         let dialect = userPreferences.selectedDialect
@@ -159,7 +228,11 @@ extension AnalysisCoordinator {
 
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
-                updateErrorCache(for: segment, with: result.errors)
+                guard isCurrentGrammarAnalysis(request) else {
+                    Logger.debug("AnalysisCoordinator: Discarding stale incremental grammar result", category: Logger.analysis)
+                    return
+                }
+
                 applyFilters(to: result.errors, sourceText: segmentContent, element: capturedElement)
 
                 // Record statistics with full details
@@ -193,6 +266,11 @@ extension AnalysisCoordinator {
     ) {
         // Capture grammar engine reference before async dispatch
         let grammarEngineRef = grammarEngine
+        let request = beginGrammarAnalysis(
+            text: text,
+            context: segment.context,
+            element: element
+        )
 
         analysisQueue.async { [weak self] in
             guard let self else { return }
@@ -220,6 +298,11 @@ extension AnalysisCoordinator {
 
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
+                guard isCurrentGrammarAnalysis(request) else {
+                    Logger.debug("AnalysisCoordinator: Discarding stale grammar result", category: Logger.analysis)
+                    return
+                }
+
                 handleGrammarResults(
                     grammarResult,
                     segment: segment,
@@ -238,7 +321,6 @@ extension AnalysisCoordinator {
         element: AXUIElement?
     ) {
         let errorsWithCachedAI = enhanceErrorsWithCachedAI(result.errors, sourceText: text)
-        updateErrorCache(for: segment, with: errorsWithCachedAI)
         applyFilters(to: errorsWithCachedAI, sourceText: text, element: element)
 
         // Record statistics

--- a/Sources/App/AnalysisCoordinator+StyleChecking.swift
+++ b/Sources/App/AnalysisCoordinator+StyleChecking.swift
@@ -2,7 +2,7 @@
 //  AnalysisCoordinator+StyleChecking.swift
 //  TextWarden
 //
-//  Style checking and performance optimization functionality extracted from AnalysisCoordinator.
+//  Style checking functionality extracted from AnalysisCoordinator.
 //  Handles Apple Intelligence style analysis, AI-enhanced readability suggestions, and style caching.
 //
 
@@ -14,170 +14,7 @@ import Foundation
     import FoundationModels
 #endif
 
-// MARK: - Performance Optimizations (User Story 4)
-
 extension AnalysisCoordinator {
-    /// Find changed region using text diffing
-    func findChangedRegion(oldText: String, newText: String) -> Range<String.Index>? {
-        guard oldText != newText else { return nil }
-
-        let oldChars = Array(oldText)
-        let newChars = Array(newText)
-
-        // Find common prefix
-        var prefixLength = 0
-        let minLength = min(oldChars.count, newChars.count)
-
-        while prefixLength < minLength, oldChars[prefixLength] == newChars[prefixLength] {
-            prefixLength += 1
-        }
-
-        // Find common suffix
-        var suffixLength = 0
-        let oldSuffixStart = oldChars.count - 1
-        let newSuffixStart = newChars.count - 1
-
-        while suffixLength < minLength - prefixLength,
-              oldChars[oldSuffixStart - suffixLength] == newChars[newSuffixStart - suffixLength]
-        {
-            suffixLength += 1
-        }
-
-        // Calculate changed region using safe index operations
-        guard let changeStart = newText.index(newText.startIndex, offsetBy: prefixLength, limitedBy: newText.endIndex),
-              let changeEnd = newText.index(newText.endIndex, offsetBy: -suffixLength, limitedBy: newText.startIndex),
-              changeStart <= changeEnd
-        else {
-            return nil
-        }
-
-        return changeStart ..< changeEnd
-    }
-
-    /// Detect sentence boundaries for context-aware analysis
-    func detectSentenceBoundaries(in text: String, around range: Range<String.Index>) -> Range<String.Index> {
-        let sentenceTerminators = CharacterSet(charactersIn: ".!?")
-
-        // Find sentence start (search backward for sentence terminator)
-        var sentenceStart = range.lowerBound
-        var searchIndex = sentenceStart
-
-        while searchIndex > text.startIndex {
-            searchIndex = text.index(before: searchIndex)
-            let char = text[searchIndex]
-
-            if let firstScalar = char.unicodeScalars.first,
-               sentenceTerminators.contains(firstScalar)
-            {
-                // Move past the terminator and any whitespace
-                sentenceStart = text.index(after: searchIndex)
-                while sentenceStart < text.endIndex, text[sentenceStart].isWhitespace {
-                    sentenceStart = text.index(after: sentenceStart)
-                }
-                break
-            }
-        }
-
-        // Find sentence end (search forward for sentence terminator)
-        var sentenceEnd = range.upperBound
-        searchIndex = sentenceEnd
-
-        while searchIndex < text.endIndex {
-            let char = text[searchIndex]
-
-            if let firstScalar = char.unicodeScalars.first,
-               sentenceTerminators.contains(firstScalar)
-            {
-                // Include the terminator
-                sentenceEnd = text.index(after: searchIndex)
-                break
-            }
-
-            searchIndex = text.index(after: searchIndex)
-        }
-
-        return sentenceStart ..< sentenceEnd
-    }
-
-    /// Merge new analysis results with cached results
-    func mergeResults(new: [GrammarErrorModel], cached: [GrammarErrorModel], changedRange: Range<Int>) -> [GrammarErrorModel] {
-        var merged: [GrammarErrorModel] = []
-
-        // Keep cached errors outside changed range
-        for error in cached {
-            let errorRange = error.start ..< error.end
-            if !errorRange.overlaps(changedRange) {
-                merged.append(error)
-            }
-        }
-
-        merged.append(contentsOf: new)
-
-        // Sort by position
-        return merged.sorted { $0.start < $1.start }
-    }
-
-    /// Check if edit is large enough to invalidate cache
-    func isLargeEdit(oldText: String, newText: String) -> Bool {
-        let diff = abs(newText.count - oldText.count)
-
-        // Consider large if >1000 chars changed (copy/paste scenario)
-        return diff > 1000
-    }
-
-    /// Purge expired cache entries
-    func purgeExpiredCache() {
-        let now = Date()
-        var expiredKeys: [String] = []
-
-        for (key, metadata) in cacheMetadata {
-            if now.timeIntervalSince(metadata.lastAccessed) > cacheExpirationTime {
-                expiredKeys.append(key)
-            }
-        }
-
-        for key in expiredKeys {
-            errorCache.removeValue(forKey: key)
-            cacheMetadata.removeValue(forKey: key)
-        }
-
-        if !expiredKeys.isEmpty {
-            Logger.debug("AnalysisCoordinator: Purged \(expiredKeys.count) expired cache entries", category: Logger.performance)
-        }
-    }
-
-    /// Evict least recently used cache entries
-    func evictLRUCacheIfNeeded() {
-        guard cacheMetadata.count > maxCachedDocuments else { return }
-
-        // Sort by last accessed time
-        let sortedEntries = cacheMetadata.sorted { $0.value.lastAccessed < $1.value.lastAccessed }
-
-        let toRemove = sortedEntries.count - maxCachedDocuments
-        for i in 0 ..< toRemove {
-            let key = sortedEntries[i].key
-            errorCache.removeValue(forKey: key)
-            cacheMetadata.removeValue(forKey: key)
-        }
-
-        Logger.debug("AnalysisCoordinator: Evicted \(toRemove) LRU cache entries", category: Logger.performance)
-    }
-
-    /// Update cache with access time tracking
-    func updateErrorCache(for segment: TextSegment, with errors: [GrammarErrorModel]) {
-        let cacheKey = segment.id.uuidString
-        errorCache[cacheKey] = errors
-
-        cacheMetadata[cacheKey] = CacheMetadata(
-            lastAccessed: Date(),
-            documentSize: segment.content.count
-        )
-
-        // Perform cache maintenance
-        purgeExpiredCache()
-        evictLRUCacheIfNeeded()
-    }
-
     // MARK: - Style Cache Methods
 
     /// Compute a cache key for style analysis based on text content, style, and temperature preset
@@ -871,14 +708,6 @@ extension AnalysisCoordinator {
         }
         return range.location
     }
-}
-
-// MARK: - Cache Metadata
-
-/// Metadata for cache entries to support LRU eviction and expiration
-struct CacheMetadata {
-    let lastAccessed: Date
-    let documentSize: Int
 }
 
 /// Metadata for style cache entries

--- a/Sources/App/AnalysisCoordinator.swift
+++ b/Sources/App/AnalysisCoordinator.swift
@@ -95,14 +95,6 @@ class AnalysisCoordinator: ObservableObject {
     /// Floating error indicator for apps without visual underlines
     let floatingIndicator: FloatingErrorIndicator
 
-    // MARK: - Grammar Analysis Cache (internal for cross-file extension access)
-
-    /// Error cache mapping text segments to detected errors
-    var errorCache: [String: [GrammarErrorModel]] = [:]
-
-    /// Cache metadata for LRU eviction
-    var cacheMetadata: [String: CacheMetadata] = [:]
-
     /// AI rephrase suggestions cache - maps original sentence text to AI-generated rephrase
     /// This cache persists across app switches and re-analyses to avoid regenerating expensive LLM suggestions
     /// Thread-safe: AIRephraseCache handles synchronization internally
@@ -133,12 +125,6 @@ class AnalysisCoordinator: ObservableObject {
 
     /// Track sentences with pending simplification requests (by range location)
     private var pendingSimplificationRequests = Set<Int>()
-
-    /// Maximum number of cached documents
-    let maxCachedDocuments = 10
-
-    /// Cache expiration time in seconds
-    let cacheExpirationTime: TimeInterval = TimingConstants.analysisCacheExpiration
 
     // MARK: - Window Tracking State (internal for cross-file extension access)
 
@@ -245,6 +231,9 @@ class AnalysisCoordinator: ObservableObject {
     /// Generation ID for style analysis - incremented on each text change
     /// Used to detect and skip stale analysis (when text changed during LLM inference)
     var styleAnalysisGeneration: UInt64 = 0
+
+    /// Generation ID for grammar analysis. Every new request or context change invalidates older work.
+    var grammarAnalysisGeneration: UInt64 = 0
 
     /// Whether style checking should run for the current text
     private var shouldRunStyleChecking: Bool {
@@ -1244,6 +1233,7 @@ class AnalysisCoordinator: ObservableObject {
             // from showing overlays for the old app after switching
             if !isSameApp {
                 Logger.trace("AnalysisCoordinator: Stopping monitoring for previous app", category: Logger.analysis)
+                invalidateGrammarAnalysis()
                 textMonitor.stopMonitoring()
                 // CRITICAL: Clear all cached analysis when switching apps to prevent
                 // showing stale errors/readability from the previous application
@@ -1554,6 +1544,7 @@ class AnalysisCoordinator: ObservableObject {
 
     /// Stop monitoring
     private func stopMonitoring() {
+        invalidateGrammarAnalysis()
         textMonitor.stopMonitoring()
         currentErrors = []
         currentSegment = nil
@@ -1760,6 +1751,12 @@ class AnalysisCoordinator: ObservableObject {
     /// Handle text change and trigger analysis
     func handleTextChange(_ text: String, in context: ApplicationContext) {
         Logger.debug("AnalysisCoordinator: Text changed in \(context.applicationName) (\(text.count) chars)", category: Logger.analysis)
+
+        // Invalidate in-flight work before any early return. Results for the old text or app
+        // must not appear while analysis is paused, focus is settling, or monitoring is cleared.
+        if currentSegment?.content != text || currentSegment?.context != context {
+            invalidateGrammarAnalysis()
+        }
 
         // Check if app is paused - skip all analysis if so
         if let pauseDuration = userPreferences.appPauseDurations[context.bundleIdentifier],
@@ -2269,8 +2266,6 @@ class AnalysisCoordinator: ObservableObject {
     // Note: Grammar analysis methods (analyzeText, analyzeFullText, analyzeChangedPortion, etc.)
     // are implemented in AnalysisCoordinator+GrammarAnalysis.swift
 
-    // Note: updateErrorCache is now implemented in the Performance Optimizations extension
-
     /// Deduplicate consecutive identical errors at the same position
     /// This prevents flooding the UI with 157 "Horizontal ellipsis" errors when they're all at the same spot
     /// But keeps separate errors for the same misspelling at different positions in the text
@@ -2777,9 +2772,9 @@ class AnalysisCoordinator: ObservableObject {
         applyFilters(to: currentErrors, sourceText: sourceText, element: textMonitor.monitoredElement)
     }
 
-    /// Clear error cache
+    /// Clear current analysis state and the style cache
     func clearCache() {
-        errorCache.removeAll()
+        invalidateGrammarAnalysis()
         currentErrors.removeAll()
         previousText = ""
         // Also clear style cache

--- a/Sources/AppConfiguration/TimingConstants.swift
+++ b/Sources/AppConfiguration/TimingConstants.swift
@@ -28,9 +28,6 @@ enum TimingConstants {
 
     // MARK: - Cache Expiration
 
-    /// Grammar analysis cache expiration (5 minutes)
-    static let analysisCacheExpiration: TimeInterval = 300
-
     /// Style analysis cache expiration (10 minutes)
     static let styleCacheExpiration: TimeInterval = 600
 

--- a/Sources/Utilities/TextIndexConverter.swift
+++ b/Sources/Utilities/TextIndexConverter.swift
@@ -152,17 +152,12 @@ enum TextIndexConverter {
     ///   - string: The string to convert within
     /// - Returns: The grapheme cluster count, or nil if out of bounds
     static func utf16ToGraphemeIndex(_ utf16Offset: Int, in string: String) -> Int? {
-        guard utf16Offset >= 0 else { return nil }
-
-        let nsString = string as NSString
-        guard utf16Offset <= nsString.length else { return nil }
-
-        // Use Range(NSRange, in:) to convert UTF-16 position to String.Index
-        let utf16Range = NSRange(location: utf16Offset, length: 0)
-        guard let range = Range(utf16Range, in: string) else { return nil }
+        guard let stringIndex = characterBoundary(forUTF16Offset: utf16Offset, in: string) else {
+            return nil
+        }
 
         // Count grapheme clusters from start to this position
-        return string.distance(from: string.startIndex, to: range.lowerBound)
+        return string.distance(from: string.startIndex, to: stringIndex)
     }
 
     // MARK: - String.Index ↔ UTF-16
@@ -182,6 +177,12 @@ enum TextIndexConverter {
     ///   - string: The string to convert within
     /// - Returns: The corresponding String.Index, or nil if out of bounds
     static func stringIndex(forUTF16Offset utf16Offset: Int, in string: String) -> String.Index? {
+        characterBoundary(forUTF16Offset: utf16Offset, in: string)
+    }
+
+    /// Convert a UTF-16 offset only when it lands on a Character boundary.
+    /// Foundation can otherwise produce a String.Index inside a surrogate pair or ZWJ sequence.
+    private static func characterBoundary(forUTF16Offset utf16Offset: Int, in string: String) -> String.Index? {
         guard utf16Offset >= 0 else { return nil }
 
         let nsString = string as NSString
@@ -189,8 +190,13 @@ enum TextIndexConverter {
 
         let utf16Range = NSRange(location: utf16Offset, length: 0)
         guard let range = Range(utf16Range, in: string) else { return nil }
+        let index = range.lowerBound
 
-        return range.lowerBound
+        guard index == string.endIndex || string.indices.contains(index) else {
+            return nil
+        }
+
+        return index
     }
 
     // MARK: - Convenience Methods

--- a/Tests/Unit/GrammarAnalysisRequestTests.swift
+++ b/Tests/Unit/GrammarAnalysisRequestTests.swift
@@ -1,0 +1,113 @@
+//
+//  GrammarAnalysisRequestTests.swift
+//  TextWardenTests
+//
+
+import ApplicationServices
+@testable import TextWarden
+import XCTest
+
+final class GrammarAnalysisRequestTests: XCTestCase {
+    private let context = ApplicationContext.application(
+        bundleIdentifier: "com.example.editor",
+        processID: 42,
+        name: "Editor"
+    )
+
+    func testRequestMatchesUnchangedAnalysisInputs() {
+        let element = AXUIElementCreateSystemWide()
+        let request = GrammarAnalysisRequest(
+            generation: 7,
+            sourceText: "Current text",
+            context: context,
+            element: element
+        )
+
+        XCTAssertTrue(
+            request.matches(
+                currentGeneration: 7,
+                currentText: "Current text",
+                currentContext: context,
+                currentElement: element
+            )
+        )
+    }
+
+    func testRequestRejectsSupersededGeneration() {
+        let request = GrammarAnalysisRequest(
+            generation: 7,
+            sourceText: "Current text",
+            context: context,
+            element: nil
+        )
+
+        XCTAssertFalse(
+            request.matches(
+                currentGeneration: 8,
+                currentText: "Current text",
+                currentContext: context,
+                currentElement: nil
+            )
+        )
+    }
+
+    func testRequestRejectsChangedText() {
+        let request = GrammarAnalysisRequest(
+            generation: 7,
+            sourceText: "Old text",
+            context: context,
+            element: nil
+        )
+
+        XCTAssertFalse(
+            request.matches(
+                currentGeneration: 7,
+                currentText: "New text",
+                currentContext: context,
+                currentElement: nil
+            )
+        )
+    }
+
+    func testRequestRejectsChangedApplicationContext() {
+        let request = GrammarAnalysisRequest(
+            generation: 7,
+            sourceText: "Current text",
+            context: context,
+            element: nil
+        )
+        let otherContext = ApplicationContext.application(
+            bundleIdentifier: "com.example.other",
+            processID: 43,
+            name: "Other"
+        )
+
+        XCTAssertFalse(
+            request.matches(
+                currentGeneration: 7,
+                currentText: "Current text",
+                currentContext: otherContext,
+                currentElement: nil
+            )
+        )
+    }
+
+    func testRequestRejectsChangedAccessibilityElement() {
+        let element = AXUIElementCreateSystemWide()
+        let request = GrammarAnalysisRequest(
+            generation: 7,
+            sourceText: "Current text",
+            context: context,
+            element: element
+        )
+
+        XCTAssertFalse(
+            request.matches(
+                currentGeneration: 7,
+                currentText: "Current text",
+                currentContext: context,
+                currentElement: nil
+            )
+        )
+    }
+}

--- a/Tests/Unit/TextIndexConverterTests.swift
+++ b/Tests/Unit/TextIndexConverterTests.swift
@@ -1,0 +1,107 @@
+//
+//  TextIndexConverterTests.swift
+//  TextWardenTests
+//
+
+import Foundation
+@testable import TextWarden
+import XCTest
+
+final class TextIndexConverterTests: XCTestCase {
+    func testASCIIIndicesUseTheSameOffsets() {
+        let text = "Hello"
+        guard let index = TextIndexConverter.scalarIndexToStringIndex(2, in: text) else {
+            XCTFail("Expected a valid scalar boundary")
+            return
+        }
+
+        XCTAssertEqual(index, text.index(text.startIndex, offsetBy: 2))
+        XCTAssertEqual(TextIndexConverter.stringIndexToScalarIndex(index, in: text), 2)
+        assertRange(
+            TextIndexConverter.scalarRangeToUTF16CFRange(start: 1, end: 4, in: text),
+            location: 1,
+            length: 3
+        )
+    }
+
+    func testEmojiBeforeErrorShiftsUTF16Location() {
+        let text = "Hi 😊 bad"
+        let badStart = "Hi 😊 ".unicodeScalars.count
+        let badEnd = badStart + "bad".unicodeScalars.count
+
+        assertRange(
+            TextIndexConverter.scalarRangeToUTF16CFRange(start: badStart, end: badEnd, in: text),
+            location: 6,
+            length: 3
+        )
+        XCTAssertEqual(TextIndexConverter.extractErrorText(start: badStart, end: badEnd, from: text), "bad")
+    }
+
+    func testZWJSequenceBeforeErrorUsesItsFullUTF16Width() {
+        let family = "👨‍👩‍👧"
+        let text = "\(family) test"
+        let testStart = "\(family) ".unicodeScalars.count
+        let testEnd = testStart + "test".unicodeScalars.count
+        let expectedLocation = ("\(family) " as NSString).length
+
+        assertRange(
+            TextIndexConverter.scalarRangeToUTF16CFRange(start: testStart, end: testEnd, in: text),
+            location: expectedLocation,
+            length: 4
+        )
+        XCTAssertEqual(TextIndexConverter.extractErrorText(start: testStart, end: testEnd, from: text), "test")
+    }
+
+    func testScalarIndexInsideGraphemeClusterIsRejected() {
+        let family = "👨‍👩‍👧"
+
+        XCTAssertNil(TextIndexConverter.scalarIndexToStringIndex(1, in: family))
+        XCTAssertNil(TextIndexConverter.extractErrorText(start: 1, end: 2, from: family))
+    }
+
+    func testScalarIndicesRejectInvalidBounds() {
+        let text = "Hello"
+
+        XCTAssertNil(TextIndexConverter.scalarIndexToStringIndex(-1, in: text))
+        XCTAssertNil(TextIndexConverter.scalarIndexToStringIndex(6, in: text))
+        XCTAssertNil(TextIndexConverter.scalarRangeToUTF16CFRange(start: 0, end: 6, in: text))
+        XCTAssertNil(TextIndexConverter.extractErrorText(start: 3, end: 3, from: text))
+        XCTAssertNil(TextIndexConverter.extractErrorText(start: 4, end: 2, from: text))
+    }
+
+    func testUTF16OffsetInsideSurrogatePairIsRejected() {
+        let text = "A😊B"
+
+        XCTAssertNil(TextIndexConverter.stringIndex(forUTF16Offset: 2, in: text))
+        XCTAssertNil(TextIndexConverter.utf16ToGraphemeIndex(2, in: text))
+    }
+
+    func testValidGraphemeBoundariesRoundTripAcrossIndexSystems() {
+        let text = "A😊é👨‍👩‍👧Z"
+        let boundaries = Array(text.indices) + [text.endIndex]
+
+        for index in boundaries {
+            let scalarOffset = TextIndexConverter.stringIndexToScalarIndex(index, in: text)
+            let utf16Offset = TextIndexConverter.utf16Offset(of: index, in: text)
+
+            XCTAssertEqual(TextIndexConverter.scalarIndexToStringIndex(scalarOffset, in: text), index)
+            XCTAssertEqual(TextIndexConverter.stringIndex(forUTF16Offset: utf16Offset, in: text), index)
+        }
+    }
+
+    private func assertRange(
+        _ range: CFRange?,
+        location: Int,
+        length: Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let range else {
+            XCTFail("Expected a valid CFRange", file: file, line: line)
+            return
+        }
+
+        XCTAssertEqual(range.location, location, file: file, line: line)
+        XCTAssertEqual(range.length, length, file: file, line: line)
+    }
+}


### PR DESCRIPTION
Discard outdated grammar analysis and reject UTF-16 offsets that split a grapheme.