### PR TITLE
feat: expand language filtering support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -109,7 +109,9 @@ The Rust dictionary combines Harper's curated dictionary with whichever bundled 
 - first names;
 - surnames.
 
-The merged dictionary is cached by that six-flag configuration. `whichlang` provides optional language detection so excluded-language documents can skip English-specific checks such as readability analysis.
+The merged dictionary is cached by that six-flag configuration. `whatlang` provides optional detection across its full 70-language catalog. Swift receives that catalog through the Rust FFI and persists selected non-English languages as ISO 639-3 codes rather than maintaining a second detector list.
+
+For each analysis, Rust detects the language of semantic segments once and records both UTF-8 byte ranges and Unicode-scalar ranges. The same summary drives the early Harper skip, readability decision, and post-analysis error filtering. Only reliable detections matching a selected language are ignored; unknown or unreliable segments fail open. Harper is skipped for the complete document only when selected languages cover more than 60% of all substantive segments.
 
 ### 4. Filter and enrich results
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -69,13 +69,13 @@ Matching is case-insensitive. You can also enable **Import macOS learned words**
 
 ### Language detection
 
-Language detection is off by default. When enabled, select the languages TextWarden should ignore:
+Language detection is off by default. Enable **Ignore selected languages** to prevent English grammar checks in passages confidently detected as a selected language.
 
-Arabic, Dutch, French, German, Hindi, Italian, Japanese, Korean, Mandarin, Portuguese, Russian, Spanish, Swedish, Turkish, and Vietnamese.
+The searchable selector contains all 69 non-English languages supported by the bundled detector. Search by English name, native name, or ISO 639-3 code. Selected languages appear first when the search field is empty.
 
-TextWarden first checks whether more than 60% of a document's detected sentences use one of the selected languages. If so, it skips the full document. Otherwise it suppresses Harper errors within individual sentences detected as one of those languages. English sentences in a mixed-language document are still checked.
+TextWarden detects language once per semantic segment, such as a sentence, paragraph, or list item. If more than 60% of all substantive segments are reliably detected as any selected language, it skips Harper and English readability analysis for the document. Otherwise it suppresses Harper errors only inside reliably matched segments. English and unselected passages in mixed-language documents remain checked.
 
-This feature prevents false positives. It does not translate or proofread non-English text.
+Uncertain detections fail open: TextWarden keeps checking the passage. This is most likely with very short, ambiguous, or closely related language samples. The feature prevents false positives; it does not translate or proofread non-English text.
 
 ## Readability
 

--- a/GrammarEngine/Cargo.lock
+++ b/GrammarEngine/Cargo.lock
@@ -2323,7 +2323,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
- "whichlang",
+ "whatlang",
 ]
 
 [[package]]
@@ -5484,10 +5484,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "whichlang"
-version = "0.1.1"
+name = "whatlang"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9aa3ad29c3d08283ac6b769e3ec15ad1ddb88af7d2e9bc402c574973b937e7"
+checksum = "f5e8f38b596e2a359b755342473520a99421e43658548c79489ee221b728c107"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "winapi"

--- a/GrammarEngine/Cargo.toml
+++ b/GrammarEngine/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["staticlib"]
 harper-core = { git = "https://github.com/Automattic/harper", tag = "v2.8.0" }
 swift-bridge = "0.1.59"
 uuid = { version = "1.0", features = ["v4"] }
-whichlang = "0.1.0"
+whatlang = "0.18.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 sysinfo = { version = "0.39", default-features = false, features = ["system"] }

--- a/GrammarEngine/src/analyzer.rs
+++ b/GrammarEngine/src/analyzer.rs
@@ -569,7 +569,7 @@ fn capitalize_pronoun_i(s: &str) -> String {
 /// * `enable_genz_slang` - Enable Gen Z slang words (ghosting, sus, slay, etc.)
 /// * `enable_it_terminology` - Enable IT terminology (kubernetes, docker, localhost, etc.)
 /// * `enable_language_detection` - Enable detection and filtering of non-English words
-/// * `excluded_languages` - List of languages to exclude from error detection (e.g., ["spanish", "german"])
+/// * `excluded_languages` - ISO 639-3 codes to exclude from error detection (e.g., ["spa", "deu"])
 /// * `enable_sentence_start_capitalization` - Enable capitalization of suggestions at sentence starts
 ///
 /// # Returns
@@ -606,18 +606,19 @@ pub fn analyze_text(
     // Parse the dialect string
     let dialect = parse_dialect(dialect_str);
 
-    // --- PHASE 0: Early Language Check ---
-    // Quick check to skip expensive Harper analysis for non-English documents.
-    // This saves ~4.5s for documents primarily in excluded languages.
+    // --- PHASE 0: Language Detection ---
+    // Detect each semantic segment once. The summary is reused after Harper so
+    // language detection is never repeated for the same analysis.
     let early_lang_start = Instant::now();
-    let early_language_check = crate::language_filter::should_skip_harper_analysis(
-        text,
-        enable_language_detection,
-        &excluded_languages,
-    );
+    let language_filter = LanguageFilter::new(enable_language_detection, excluded_languages);
+    let excluded_langs_count = language_filter.excluded_language_count();
+    let language_summary = language_filter.analyze(text);
+    let early_language_check = language_summary
+        .as_ref()
+        .is_some_and(|summary| language_filter.should_skip_harper(summary));
     let early_language_check_ms = early_lang_start.elapsed().as_millis() as u64;
 
-    if let Some(true) = early_language_check {
+    if early_language_check {
         let word_count = text.split_whitespace().count();
         tracing::info!(
             "Early language bailout: {} words, {}ms - document primarily in excluded language",
@@ -958,15 +959,17 @@ pub fn analyze_text(
         );
     }
 
-    // Apply language detection filter to remove errors for non-English words
-    // This is the optimized approach: we only detect language for words that Harper flagged
-    let excluded_langs_count = excluded_languages.len();
-    let filter = LanguageFilter::new(enable_language_detection, excluded_languages);
+    // Apply the language summary calculated before Harper.
     let errors_before_filter = errors.len();
-    errors = filter.filter_errors(errors, text);
+    errors = match language_summary.as_ref() {
+        Some(summary) => language_filter.filter_errors_with_summary(errors, summary),
+        None => errors,
+    };
 
     // Check if document is primarily non-English (for readability skip)
-    let is_non_english_document = filter.is_document_primarily_non_english(text);
+    let is_non_english_document = language_summary
+        .as_ref()
+        .is_some_and(|summary| language_filter.should_skip_harper(summary));
 
     if enable_language_detection {
         tracing::info!(
@@ -1022,6 +1025,23 @@ mod tests {
                 std::println!($($arg)*);
             }
         }};
+    }
+
+    const ENGLISH_DETECTION_SENTENCE: &str = "This is a detailed English sentence with enough characteristic words for automatic language detection to produce a useful and dependable result.";
+    const GERMAN_DETECTION_SENTENCE: &str = "Dies ist ein ausführlicher deutscher Satz mit genügend charakteristischen Wörtern, damit die automatische Spracherkennung zuverlässig funktioniert.";
+    const SPANISH_DETECTION_SENTENCE: &str = "Esta es una oración española detallada con suficientes palabras características para que la detección automática del idioma funcione de manera fiable.";
+    const FRENCH_DETECTION_SENTENCE: &str = "Ceci est une phrase française détaillée qui contient suffisamment de mots caractéristiques pour que la détection automatique de la langue fonctionne correctement.";
+    const ITALIAN_DETECTION_SENTENCE: &str = "Questa è una frase italiana dettagliata con abbastanza parole caratteristiche perché il rilevamento automatico della lingua funzioni in modo affidabile.";
+    const PORTUGUESE_DETECTION_SENTENCE: &str = "Esta é uma frase portuguesa detalhada com palavras características suficientes para que a detecção automática do idioma funcione de forma confiável.";
+    const DUTCH_DETECTION_SENTENCE: &str = "Dit is een uitgebreide Nederlandse zin met voldoende kenmerkende woorden om de automatische taalherkenning betrouwbaar te laten werken.";
+    const SWEDISH_DETECTION_SENTENCE: &str = "Det här är en detaljerad svensk mening med tillräckligt många karakteristiska ord för att den automatiska språkidentifieringen ska fungera tillförlitligt.";
+    const TURKISH_DETECTION_SENTENCE: &str = "Bu, otomatik dil algılamanın güvenilir bir şekilde çalışması için yeterli karakteristik kelime içeren ayrıntılı bir Türkçe cümledir.";
+
+    fn error_text(text: &str, error: &GrammarError) -> String {
+        text.chars()
+            .skip(error.start)
+            .take(error.end.saturating_sub(error.start))
+            .collect()
     }
 
     #[test]
@@ -2597,9 +2617,9 @@ mod tests {
     fn test_language_detection_german_word_filtered() {
         // Enable language detection with German excluded
         // Use complete German sentence followed by English sentence
-        let text = "Hallo Welt, wie geht es dir? How are you doing today?";
+        let text = format!("{GERMAN_DETECTION_SENTENCE} {ENGLISH_DETECTION_SENTENCE}");
         let result = analyze_text(
-            text,
+            &text,
             "American",
             false,
             false,
@@ -2608,7 +2628,7 @@ mod tests {
             false,
             false,
             true, // Enable language detection
-            vec!["german".to_string()],
+            vec!["deu".to_string()],
             true,
             true, // enforce_oxford_comma
             true, // check_ellipsis
@@ -2629,8 +2649,12 @@ mod tests {
             );
         }
 
-        // Errors in the German sentence (0..30) should be filtered
-        let german_sentence_errors = result.errors.iter().filter(|e| e.start < 30).count();
+        let german_end = GERMAN_DETECTION_SENTENCE.chars().count();
+        let german_sentence_errors = result
+            .errors
+            .iter()
+            .filter(|error| error.start < german_end)
+            .count();
 
         assert_eq!(
             german_sentence_errors, 0,
@@ -2688,9 +2712,9 @@ mod tests {
     #[test]
     fn test_language_detection_spanish_words() {
         // Use complete Spanish sentence followed by English sentence
-        let text = "Hola amigos, como estas hoy? Let's continue in English.";
+        let text = format!("{SPANISH_DETECTION_SENTENCE} {ENGLISH_DETECTION_SENTENCE}");
         let result = analyze_text(
-            text,
+            &text,
             "American",
             false,
             false,
@@ -2699,7 +2723,7 @@ mod tests {
             false,
             false,
             true,
-            vec!["spanish".to_string()],
+            vec!["spa".to_string()],
             true,
             true, // enforce_oxford_comma
             true, // check_ellipsis
@@ -2720,8 +2744,12 @@ mod tests {
             );
         }
 
-        // Errors in Spanish sentence (0..29) should be filtered
-        let spanish_errors = result.errors.iter().filter(|e| e.start < 29).count();
+        let spanish_end = SPANISH_DETECTION_SENTENCE.chars().count();
+        let spanish_errors = result
+            .errors
+            .iter()
+            .filter(|error| error.start < spanish_end)
+            .count();
 
         assert_eq!(
             spanish_errors, 0,
@@ -2732,9 +2760,9 @@ mod tests {
     #[test]
     fn test_language_detection_french_greeting() {
         // Use complete French sentence followed by English sentence
-        let text = "Bonjour mes amis, comment allez-vous? I have a question.";
+        let text = format!("{FRENCH_DETECTION_SENTENCE} {ENGLISH_DETECTION_SENTENCE}");
         let result = analyze_text(
-            text,
+            &text,
             "American",
             false,
             false,
@@ -2743,7 +2771,7 @@ mod tests {
             false,
             false,
             true,
-            vec!["french".to_string()],
+            vec!["fra".to_string()],
             true,
             true, // enforce_oxford_comma
             true, // check_ellipsis
@@ -2764,8 +2792,12 @@ mod tests {
             );
         }
 
-        // Errors in French sentence (0..38) should be filtered
-        let french_errors = result.errors.iter().filter(|e| e.start < 38).count();
+        let french_end = FRENCH_DETECTION_SENTENCE.chars().count();
+        let french_errors = result
+            .errors
+            .iter()
+            .filter(|error| error.start < french_end)
+            .count();
 
         assert_eq!(
             french_errors, 0,
@@ -2775,10 +2807,12 @@ mod tests {
 
     #[test]
     fn test_language_detection_multiple_languages() {
-        // Use longer complete sentences in different languages so whichlang can detect them
-        let text = "Hola amigos, como estas hoy? Bonjour mes amis, comment allez-vous? Hallo Freunde, wie geht es euch? Welcome to the meeting.";
+        // Use longer complete sentences so the language detector has enough context.
+        let text = format!(
+            "{SPANISH_DETECTION_SENTENCE} {FRENCH_DETECTION_SENTENCE} {GERMAN_DETECTION_SENTENCE} {ENGLISH_DETECTION_SENTENCE}"
+        );
         let result = analyze_text(
-            text,
+            &text,
             "American",
             false,
             false,
@@ -2787,11 +2821,7 @@ mod tests {
             false,
             false,
             true,
-            vec![
-                "spanish".to_string(),
-                "french".to_string(),
-                "german".to_string(),
-            ],
+            vec!["spa".to_string(), "fra".to_string(), "deu".to_string()],
             true,
             true, // enforce_oxford_comma
             true, // check_ellipsis
@@ -2812,41 +2842,16 @@ mod tests {
             );
         }
 
-        // Errors in Spanish sentence (0..29) should be filtered
-        let spanish_errors = result.errors.iter().filter(|e| e.start < 29).count();
-        // Errors in French sentence (29..66) should be filtered
-        let french_errors = result
-            .errors
-            .iter()
-            .filter(|e| e.start >= 29 && e.start < 66)
-            .count();
-        // Errors in German sentence (66..99) should be filtered
-        let german_errors = result
-            .errors
-            .iter()
-            .filter(|e| e.start >= 66 && e.start < 99)
-            .count();
-
-        assert_eq!(
-            spanish_errors, 0,
-            "Spanish sentence errors should be filtered"
-        );
-        assert_eq!(
-            french_errors, 0,
-            "French sentence errors should be filtered"
-        );
-        assert_eq!(
-            german_errors, 0,
-            "German sentence errors should be filtered"
-        );
+        assert!(result.is_non_english_document);
+        assert!(result.errors.is_empty());
     }
 
     #[test]
     fn test_language_detection_exclude_one_language_only() {
         // Spanish sentence and German sentence, but only Spanish excluded
-        let text = "Hola amigos, como estas? Hallo Welt, wie geht es dir?";
+        let text = format!("{SPANISH_DETECTION_SENTENCE} {GERMAN_DETECTION_SENTENCE}");
         let result = analyze_text(
-            text,
+            &text,
             "American",
             false,
             false,
@@ -2855,7 +2860,7 @@ mod tests {
             false,
             false,
             true,
-            vec!["spanish".to_string()], // Only Spanish excluded
+            vec!["spa".to_string()], // Only Spanish excluded
             true,
             true, // enforce_oxford_comma
             true, // check_ellipsis
@@ -2876,8 +2881,12 @@ mod tests {
             );
         }
 
-        // Errors in Spanish sentence (0..25) should be filtered
-        let spanish_errors = result.errors.iter().filter(|e| e.start < 25).count();
+        let spanish_end = SPANISH_DETECTION_SENTENCE.chars().count();
+        let spanish_errors = result
+            .errors
+            .iter()
+            .filter(|error| error.start < spanish_end)
+            .count();
 
         // German sentence errors should NOT be filtered (German not excluded)
         // We just verify Spanish is filtered
@@ -2891,9 +2900,9 @@ mod tests {
     fn test_language_detection_with_slang_enabled() {
         // Test that language detection works alongside slang dictionaries
         // Spanish sentence followed by English with slang
-        let text = "Hola amigos, como estas? BTW, that's totally sus.";
+        let text = format!("{SPANISH_DETECTION_SENTENCE} BTW, that's totally sus.");
         let result = analyze_text(
-            text,
+            &text,
             "American",
             true,  // Internet abbreviations ON
             true,  // Gen Z slang ON
@@ -2902,7 +2911,7 @@ mod tests {
             false,
             false,
             true, // Language detection ON
-            vec!["spanish".to_string()],
+            vec!["spa".to_string()],
             true,
             true, // enforce_oxford_comma
             true, // check_ellipsis
@@ -2923,19 +2932,23 @@ mod tests {
             );
         }
 
-        // Errors in Spanish sentence (0..25) should be filtered
-        let spanish_errors = result.errors.iter().filter(|e| e.start < 25).count();
+        let spanish_end = SPANISH_DETECTION_SENTENCE.chars().count();
+        let spanish_errors = result
+            .errors
+            .iter()
+            .filter(|error| error.start < spanish_end)
+            .count();
 
         // "BTW" and "sus" in English sentence should NOT have SPELLING errors (slang dictionaries)
         // (Style suggestions are OK)
         let btw_spelling = result
             .errors
             .iter()
-            .any(|e| &text[e.start..e.end] == "BTW" && e.category == "Spelling");
+            .any(|error| error_text(&text, error) == "BTW" && error.category == "Spelling");
         let sus_spelling = result
             .errors
             .iter()
-            .any(|e| &text[e.start..e.end] == "sus" && e.category == "Spelling");
+            .any(|error| error_text(&text, error) == "sus" && error.category == "Spelling");
 
         assert_eq!(
             spanish_errors, 0,
@@ -2955,10 +2968,10 @@ mod tests {
     fn test_language_detection_preserves_real_errors() {
         // Ensure real English errors are still caught
         // German sentence followed by English sentence with typo
-        let text = "Hallo Welt, wie geht es dir? I recieve your message.";
+        let text = format!("{GERMAN_DETECTION_SENTENCE} I recieve your message.");
         // "Hallo..." = German sentence (filtered), "I recieve..." = English typo (should be caught)
         let result = analyze_text(
-            text,
+            &text,
             "American",
             false,
             false,
@@ -2967,7 +2980,7 @@ mod tests {
             false,
             false,
             true,
-            vec!["german".to_string()],
+            vec!["deu".to_string()],
             true,
             true, // enforce_oxford_comma
             true, // check_ellipsis
@@ -2988,8 +3001,12 @@ mod tests {
             );
         }
 
-        // Errors in German sentence (0..30) should be filtered
-        let german_errors = result.errors.iter().filter(|e| e.start < 30).count();
+        let german_end = GERMAN_DETECTION_SENTENCE.chars().count();
+        let german_errors = result
+            .errors
+            .iter()
+            .filter(|error| error.start < german_end)
+            .count();
         assert_eq!(
             german_errors, 0,
             "German sentence errors should be filtered"
@@ -3000,7 +3017,7 @@ mod tests {
         let has_recieve = result
             .errors
             .iter()
-            .any(|e| &text[e.start..e.end] == "recieve");
+            .any(|error| error_text(&text, error) == "recieve");
         if has_recieve {
             println!("✅ Real English error 'recieve' was preserved");
         }
@@ -3010,9 +3027,9 @@ mod tests {
     fn test_language_detection_code_switching() {
         // Test code-switching scenario (common in bilingual contexts)
         // Use Spanish sentence followed by English sentence
-        let text = "Fui al mercado ayer. I went shopping yesterday.";
+        let text = format!("{SPANISH_DETECTION_SENTENCE} {ENGLISH_DETECTION_SENTENCE}");
         let result = analyze_text(
-            text,
+            &text,
             "American",
             false,
             false,
@@ -3021,7 +3038,7 @@ mod tests {
             false,
             false,
             true,
-            vec!["spanish".to_string()],
+            vec!["spa".to_string()],
             true,
             true, // enforce_oxford_comma
             true, // check_ellipsis
@@ -3042,8 +3059,12 @@ mod tests {
             );
         }
 
-        // Errors in Spanish sentence (0..21) should be filtered
-        let spanish_errors = result.errors.iter().filter(|e| e.start < 21).count();
+        let spanish_end = SPANISH_DETECTION_SENTENCE.chars().count();
+        let spanish_errors = result
+            .errors
+            .iter()
+            .filter(|error| error.start < spanish_end)
+            .count();
         assert_eq!(
             spanish_errors, 0,
             "Spanish sentence errors should be filtered"
@@ -3121,14 +3142,88 @@ mod tests {
     }
 
     #[test]
+    fn test_latvian_issue_samples_filter_real_harper_errors_only_when_selected() {
+        let samples = [
+            "Šodien ir silta diena un es rakstu vēstuli.",
+            "Latviešu valoda ir skaista un bagāta valoda, kurā runā Latvijā.",
+        ];
+
+        for text in samples {
+            let baseline = analyze_text(
+                text,
+                "American",
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                vec![],
+                true,
+                true,
+                true,
+                true,
+                true,
+            );
+            assert!(
+                !baseline.errors.is_empty(),
+                "fixture must produce Harper errors without language filtering"
+            );
+
+            let unselected = analyze_text(
+                text,
+                "American",
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                true,
+                vec!["lit".to_string()],
+                true,
+                true,
+                true,
+                true,
+                true,
+            );
+            assert!(
+                !unselected.errors.is_empty(),
+                "Latvian errors must remain when only Lithuanian is selected"
+            );
+
+            let selected = analyze_text(
+                text,
+                "American",
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                true,
+                vec!["lav".to_string()],
+                true,
+                true,
+                true,
+                true,
+                true,
+            );
+            assert!(selected.errors.is_empty());
+            assert!(selected.is_non_english_document);
+        }
+    }
+
+    #[test]
     fn test_language_detection_all_dialects() {
         // Test that language detection works with all English dialects
         let dialects = vec!["American", "British", "Canadian", "Australian", "Indian"];
-        let text = "Hallo Welt, wie geht es dir? English sentence here.";
+        let text = format!("{GERMAN_DETECTION_SENTENCE} {ENGLISH_DETECTION_SENTENCE}");
 
         for dialect in dialects {
             let result = analyze_text(
-                text,
+                &text,
                 dialect,
                 false,
                 false,
@@ -3137,7 +3232,7 @@ mod tests {
                 false,
                 false,
                 true,
-                vec!["german".to_string()],
+                vec!["deu".to_string()],
                 true,
                 true, // enforce_oxford_comma
                 true, // check_ellipsis
@@ -3149,8 +3244,12 @@ mod tests {
             println!("Text: '{}'", text);
             println!("Errors: {}", result.errors.len());
 
-            // German sentence errors (0..30) should be filtered regardless of dialect
-            let german_errors = result.errors.iter().filter(|e| e.start < 30).count();
+            let german_end = GERMAN_DETECTION_SENTENCE.chars().count();
+            let german_errors = result
+                .errors
+                .iter()
+                .filter(|error| error.start < german_end)
+                .count();
             assert_eq!(
                 german_errors, 0,
                 "German sentence errors should be filtered for dialect {}",
@@ -3191,9 +3290,9 @@ mod tests {
     #[test]
     fn test_language_detection_italian() {
         // Test Italian language detection and filtering
-        let text = "Ciao amici, come stai oggi? Welcome to our Italian class.";
+        let text = format!("{ITALIAN_DETECTION_SENTENCE} {ENGLISH_DETECTION_SENTENCE}");
         let result = analyze_text(
-            text,
+            &text,
             "American",
             false,
             false,
@@ -3202,7 +3301,7 @@ mod tests {
             false,
             false,
             true,
-            vec!["italian".to_string()],
+            vec!["ita".to_string()],
             true,
             true, // enforce_oxford_comma
             true, // check_ellipsis
@@ -3223,8 +3322,12 @@ mod tests {
             );
         }
 
-        // Errors in Italian sentence (0..28) should be filtered
-        let italian_errors = result.errors.iter().filter(|e| e.start < 28).count();
+        let italian_end = ITALIAN_DETECTION_SENTENCE.chars().count();
+        let italian_errors = result
+            .errors
+            .iter()
+            .filter(|error| error.start < italian_end)
+            .count();
         assert_eq!(
             italian_errors, 0,
             "Italian sentence errors should be filtered"
@@ -3234,9 +3337,9 @@ mod tests {
     #[test]
     fn test_language_detection_portuguese() {
         // Test Portuguese language detection and filtering
-        let text = "Olá meus amigos, como você está? This is an English sentence.";
+        let text = format!("{PORTUGUESE_DETECTION_SENTENCE} {ENGLISH_DETECTION_SENTENCE}");
         let result = analyze_text(
-            text,
+            &text,
             "American",
             false,
             false,
@@ -3245,7 +3348,7 @@ mod tests {
             false,
             false,
             true,
-            vec!["portuguese".to_string()],
+            vec!["por".to_string()],
             true,
             true, // enforce_oxford_comma
             true, // check_ellipsis
@@ -3266,8 +3369,12 @@ mod tests {
             );
         }
 
-        // Errors in Portuguese sentence (0..33) should be filtered
-        let portuguese_errors = result.errors.iter().filter(|e| e.start < 33).count();
+        let portuguese_end = PORTUGUESE_DETECTION_SENTENCE.chars().count();
+        let portuguese_errors = result
+            .errors
+            .iter()
+            .filter(|error| error.start < portuguese_end)
+            .count();
         assert_eq!(
             portuguese_errors, 0,
             "Portuguese sentence errors should be filtered"
@@ -3277,9 +3384,9 @@ mod tests {
     #[test]
     fn test_language_detection_dutch() {
         // Test Dutch language detection and filtering
-        let text = "Hallo allemaal, hoe gaat het met jullie? Back to English now.";
+        let text = format!("{DUTCH_DETECTION_SENTENCE} {ENGLISH_DETECTION_SENTENCE}");
         let result = analyze_text(
-            text,
+            &text,
             "American",
             false,
             false,
@@ -3288,7 +3395,7 @@ mod tests {
             false,
             false,
             true,
-            vec!["dutch".to_string()],
+            vec!["nld".to_string()],
             true,
             true, // enforce_oxford_comma
             true, // check_ellipsis
@@ -3309,17 +3416,21 @@ mod tests {
             );
         }
 
-        // Errors in Dutch sentence (0..42) should be filtered
-        let dutch_errors = result.errors.iter().filter(|e| e.start < 42).count();
+        let dutch_end = DUTCH_DETECTION_SENTENCE.chars().count();
+        let dutch_errors = result
+            .errors
+            .iter()
+            .filter(|error| error.start < dutch_end)
+            .count();
         assert_eq!(dutch_errors, 0, "Dutch sentence errors should be filtered");
     }
 
     #[test]
     fn test_language_detection_swedish() {
         // Test Swedish language detection and filtering
-        let text = "Hej allihopa, hur mår ni idag? The meeting starts soon.";
+        let text = format!("{SWEDISH_DETECTION_SENTENCE} {ENGLISH_DETECTION_SENTENCE}");
         let result = analyze_text(
-            text,
+            &text,
             "American",
             false,
             false,
@@ -3328,7 +3439,7 @@ mod tests {
             false,
             false,
             true,
-            vec!["swedish".to_string()],
+            vec!["swe".to_string()],
             true,
             true, // enforce_oxford_comma
             true, // check_ellipsis
@@ -3349,8 +3460,12 @@ mod tests {
             );
         }
 
-        // Errors in Swedish sentence (0..31) should be filtered
-        let swedish_errors = result.errors.iter().filter(|e| e.start < 31).count();
+        let swedish_end = SWEDISH_DETECTION_SENTENCE.chars().count();
+        let swedish_errors = result
+            .errors
+            .iter()
+            .filter(|error| error.start < swedish_end)
+            .count();
         assert_eq!(
             swedish_errors, 0,
             "Swedish sentence errors should be filtered"
@@ -3360,9 +3475,9 @@ mod tests {
     #[test]
     fn test_language_detection_turkish() {
         // Test Turkish language detection and filtering
-        let text = "Merhaba arkadaşlar, nasılsınız bugün? Let's continue in English.";
+        let text = format!("{TURKISH_DETECTION_SENTENCE} {ENGLISH_DETECTION_SENTENCE}");
         let result = analyze_text(
-            text,
+            &text,
             "American",
             false,
             false,
@@ -3371,7 +3486,7 @@ mod tests {
             false,
             false,
             true,
-            vec!["turkish".to_string()],
+            vec!["tur".to_string()],
             true,
             true, // enforce_oxford_comma
             true, // check_ellipsis
@@ -3392,8 +3507,12 @@ mod tests {
             );
         }
 
-        // Errors in Turkish sentence (0..39) should be filtered
-        let turkish_errors = result.errors.iter().filter(|e| e.start < 39).count();
+        let turkish_end = TURKISH_DETECTION_SENTENCE.chars().count();
+        let turkish_errors = result
+            .errors
+            .iter()
+            .filter(|error| error.start < turkish_end)
+            .count();
         assert_eq!(
             turkish_errors, 0,
             "Turkish sentence errors should be filtered"
@@ -3404,9 +3523,9 @@ mod tests {
     fn test_language_detection_non_excluded_language_kept() {
         // Test that non-excluded languages are NOT filtered
         // Italian excluded, but German should still show errors
-        let text = "Ciao amici, come stai? Hallo Welt, wie geht es dir?";
+        let text = format!("{ITALIAN_DETECTION_SENTENCE} {GERMAN_DETECTION_SENTENCE}");
         let result = analyze_text(
-            text,
+            &text,
             "American",
             false,
             false,
@@ -3415,7 +3534,7 @@ mod tests {
             false,
             false,
             true,
-            vec!["italian".to_string()], // Only Italian excluded, not German
+            vec!["ita".to_string()], // Only Italian excluded, not German
             true,
             true, // enforce_oxford_comma
             true, // check_ellipsis
@@ -3436,8 +3555,12 @@ mod tests {
             );
         }
 
-        // Errors in Italian sentence (0..22) should be filtered
-        let italian_errors = result.errors.iter().filter(|e| e.start < 22).count();
+        let italian_end = ITALIAN_DETECTION_SENTENCE.chars().count();
+        let italian_errors = result
+            .errors
+            .iter()
+            .filter(|error| error.start < italian_end)
+            .count();
         assert_eq!(
             italian_errors, 0,
             "Italian sentence errors should be filtered"
@@ -3725,26 +3848,11 @@ mod tests {
         // Note: Release builds are ~3x faster (~180-200ms)
         use std::time::Instant;
 
-        let all_langs = vec![
-            "spanish",
-            "french",
-            "german",
-            "italian",
-            "portuguese",
-            "dutch",
-            "russian",
-            "mandarin",
-            "japanese",
-            "korean",
-            "arabic",
-            "hindi",
-            "turkish",
-            "swedish",
-            "vietnamese",
-        ]
-        .iter()
-        .map(|s| s.to_string())
-        .collect();
+        let all_langs = whatlang::Lang::all()
+            .iter()
+            .filter(|language| **language != whatlang::Lang::Eng)
+            .map(|language| language.code().to_string())
+            .collect();
 
         let text = "This is a test with multiple foreign words like Hallo Bonjour Gracias Ciao scattered throughout. \
                     The system should handle many excluded languages efficiently without degradation. \
@@ -3768,6 +3876,78 @@ mod tests {
             elapsed.as_millis() < 1500,
             "Analysis with all languages excluded too slow: {} ms (expected < 1500 ms)",
             elapsed.as_millis()
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn test_performance_language_detection_end_to_end_gate() {
+        use std::hint::black_box;
+        use std::time::{Duration, Instant};
+
+        let text = "This is a representative grammar analysis sample with a few foreign words such as Hallo and Danke. \
+                    Language detection should add little overhead while the English grammar engine processes the same document. \
+                    Additional sentences make this a realistic sample for measuring release performance on approximately two hundred words. \
+                    The detector evaluates each semantic segment once and preserves uncertain text for normal English checking. "
+            .repeat(4);
+
+        fn measure(text: &str, enabled: bool) -> Duration {
+            let start = Instant::now();
+            black_box(analyze_text(
+                black_box(text),
+                "American",
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                enabled,
+                if enabled {
+                    vec!["deu".to_string()]
+                } else {
+                    vec![]
+                },
+                true,
+                true,
+                true,
+                true,
+                true,
+            ));
+            start.elapsed()
+        }
+
+        // Warm caches before comparing identical analysis work.
+        black_box(measure(&text, false));
+        black_box(measure(&text, true));
+
+        let mut disabled_samples = Vec::new();
+        let mut enabled_samples = Vec::new();
+        for _ in 0..5 {
+            disabled_samples.push(measure(&text, false));
+            enabled_samples.push(measure(&text, true));
+        }
+        disabled_samples.sort();
+        enabled_samples.sort();
+
+        let disabled = disabled_samples[disabled_samples.len() / 2];
+        let enabled = enabled_samples[enabled_samples.len() / 2];
+        let overhead = enabled.as_secs_f64() / disabled.as_secs_f64() - 1.0;
+
+        println!("200-word detection disabled: {} ms", disabled.as_millis());
+        println!("200-word detection enabled: {} ms", enabled.as_millis());
+        println!("end-to-end detection overhead: {:.2}%", overhead * 100.0);
+
+        assert!(
+            enabled < Duration::from_millis(500),
+            "release analysis must remain under 500 ms; took {} ms",
+            enabled.as_millis()
+        );
+        assert!(
+            enabled.as_secs_f64() <= disabled.as_secs_f64() * 1.10,
+            "language detection overhead must remain within 10%; disabled={} ms enabled={} ms",
+            disabled.as_millis(),
+            enabled.as_millis()
         );
     }
 

--- a/GrammarEngine/src/bridge.rs
+++ b/GrammarEngine/src/bridge.rs
@@ -11,6 +11,7 @@ use std::sync::Once;
 use sysinfo::{Pid, ProcessesToUpdate, System};
 use tracing::Level;
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use whatlang::Lang;
 
 static INIT_LOGGING: Once = Once::new();
 
@@ -54,6 +55,17 @@ mod ffi {
         fn document_parse_ms(&self) -> u64;
         fn harper_lint_ms(&self) -> u64;
         fn post_process_ms(&self) -> u64;
+    }
+
+    // Opaque type for the detector-backed language catalog.
+    extern "Rust" {
+        type LanguageInfo;
+
+        fn code(&self) -> String;
+        fn english_name(&self) -> String;
+        fn native_name(&self) -> String;
+
+        fn supported_languages() -> Vec<LanguageInfo>;
     }
 
     extern "Rust" {
@@ -134,6 +146,38 @@ impl GrammarError {
     fn suggestions(&self) -> Vec<String> {
         self.suggestions.clone()
     }
+}
+
+#[derive(Clone)]
+pub struct LanguageInfo {
+    code: String,
+    english_name: String,
+    native_name: String,
+}
+
+impl LanguageInfo {
+    fn code(&self) -> String {
+        self.code.clone()
+    }
+
+    fn english_name(&self) -> String {
+        self.english_name.clone()
+    }
+
+    fn native_name(&self) -> String {
+        self.native_name.clone()
+    }
+}
+
+fn supported_languages() -> Vec<LanguageInfo> {
+    Lang::all()
+        .iter()
+        .map(|language| LanguageInfo {
+            code: language.code().to_string(),
+            english_name: language.eng_name().to_string(),
+            native_name: language.name().to_string(),
+        })
+        .collect()
 }
 
 pub struct AnalysisResult {

--- a/GrammarEngine/src/language_filter.rs
+++ b/GrammarEngine/src/language_filter.rs
@@ -1,205 +1,252 @@
-// Language Filter - Sentence-level language detection
+// Language Filter - semantic-segment language detection
 //
-// Splits text into sentences, detects the language of each sentence,
-// and filters out grammar errors in non-English sentences.
+// Splits text into semantic segments, detects each segment once, and reuses that
+// summary for the early Harper bailout, readability, and error filtering.
 
 use crate::analyzer::GrammarError;
-use whichlang::{detect_language, Lang};
+use std::collections::HashSet;
+use std::sync::LazyLock;
+use whatlang::{Detector, Lang};
 
-/// Threshold for considering a document "primarily" in a given language.
-/// If more than this ratio of sentences are in an excluded language, the document
-/// is treated as non-English for filtering purposes.
+/// Threshold for treating a document as primarily written in selected languages.
 const NON_ENGLISH_THRESHOLD: f64 = 0.6;
 
-/// Language filter configuration
+/// Whatlang must consider its complete language catalog. Restricting candidates to
+/// selected languages can force unrelated text into a selected language.
+static LANGUAGE_DETECTOR: LazyLock<Detector> = LazyLock::new(Detector::new);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct SegmentRange {
+    byte_start: usize,
+    byte_end: usize,
+    scalar_start: usize,
+    scalar_end: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct DetectedSegment {
+    range: SegmentRange,
+    language: Option<Lang>,
+    confidence: f64,
+    reliable: bool,
+}
+
+/// Reusable language detections for one document.
+#[derive(Clone, Debug, Default)]
+pub struct LanguageDetectionSummary {
+    segments: Vec<DetectedSegment>,
+}
+
+impl LanguageDetectionSummary {
+    fn detect(text: &str) -> Self {
+        let segments = split_into_segments(text)
+            .into_iter()
+            .map(|range| {
+                let info = text
+                    .get(range.byte_start..range.byte_end)
+                    .and_then(|segment| LANGUAGE_DETECTOR.detect(segment));
+
+                DetectedSegment {
+                    range,
+                    language: info.as_ref().map(|detected| detected.lang()),
+                    confidence: info.as_ref().map_or(0.0, |detected| detected.confidence()),
+                    reliable: info.as_ref().is_some_and(|detected| detected.is_reliable()),
+                }
+            })
+            .collect();
+
+        Self { segments }
+    }
+
+    fn selected_ratio(&self, selected_languages: &HashSet<Lang>) -> f64 {
+        if self.segments.is_empty() {
+            return 0.0;
+        }
+
+        let selected_count = self
+            .segments
+            .iter()
+            .filter(|segment| {
+                segment.reliable
+                    && segment
+                        .language
+                        .is_some_and(|language| selected_languages.contains(&language))
+            })
+            .count();
+
+        selected_count as f64 / self.segments.len() as f64
+    }
+
+    fn is_primarily_selected(&self, selected_languages: &HashSet<Lang>) -> bool {
+        self.selected_ratio(selected_languages) > NON_ENGLISH_THRESHOLD
+    }
+}
+
+/// Language filter configuration.
 pub struct LanguageFilter {
     enabled: bool,
-    excluded_languages: Vec<Lang>,
+    excluded_languages: HashSet<Lang>,
 }
 
 impl LanguageFilter {
-    /// Create a new language filter
-    ///
-    /// # Arguments
-    /// * `enabled` - Whether language detection is enabled
-    /// * `excluded_languages` - List of language codes to exclude (e.g., ["spanish", "german"])
+    /// Create a language filter from ISO 639-3 language codes.
     pub fn new(enabled: bool, excluded_languages: Vec<String>) -> Self {
-        let langs = excluded_languages
-            .iter()
-            .filter_map(|s| lang_from_string(s))
+        let excluded_languages = excluded_languages
+            .into_iter()
+            .filter_map(|value| {
+                Lang::from_code(value.clone())
+                    .or_else(|| legacy_language_code(&value).and_then(Lang::from_code))
+            })
+            .filter(|language| *language != Lang::Eng)
             .collect();
 
         Self {
             enabled,
-            excluded_languages: langs,
+            excluded_languages,
         }
     }
 
-    /// Filter out errors for non-English sentences
-    ///
-    /// Uses sentence-level language detection: splits text into sentences,
-    /// detects the language of each sentence, and filters errors in non-English sentences.
-    ///
-    /// # Arguments
-    /// * `errors` - Errors detected by Harper
-    /// * `text` - Original text that was analyzed
-    ///
-    /// # Returns
-    /// Filtered list of errors with errors in non-English sentences removed
-    pub fn filter_errors(&self, errors: Vec<GrammarError>, text: &str) -> Vec<GrammarError> {
-        tracing::debug!(
-            "LanguageFilter: enabled={}, excluded_languages={:?}",
-            self.enabled,
-            self.excluded_languages
-        );
+    pub fn excluded_language_count(&self) -> usize {
+        self.excluded_languages.len()
+    }
 
+    /// Detect every substantive semantic segment once.
+    pub fn analyze(&self, text: &str) -> Option<LanguageDetectionSummary> {
         if !self.enabled || self.excluded_languages.is_empty() {
-            tracing::debug!(
-                "LanguageFilter: Skipping (enabled={}, excluded_empty={})",
-                self.enabled,
-                self.excluded_languages.is_empty()
-            );
+            return None;
+        }
+
+        Some(LanguageDetectionSummary::detect(text))
+    }
+
+    pub fn should_skip_harper(&self, summary: &LanguageDetectionSummary) -> bool {
+        summary.is_primarily_selected(&self.excluded_languages)
+    }
+
+    /// Filter errors using a summary already calculated before Harper ran.
+    pub fn filter_errors_with_summary(
+        &self,
+        errors: Vec<GrammarError>,
+        summary: &LanguageDetectionSummary,
+    ) -> Vec<GrammarError> {
+        if !self.enabled || self.excluded_languages.is_empty() {
             return errors;
         }
 
-        // First, check if document is primarily in an excluded language
-        // If so, filter ALL errors (no point in sentence-level detection)
-        if let Some((lang, ratio)) =
-            calculate_excluded_language_ratio(text, &self.excluded_languages)
-        {
+        if self.should_skip_harper(summary) {
             tracing::info!(
-                "LanguageFilter: Document language {:?} detected ({:.0}% of sentences)",
-                lang,
-                ratio * 100.0
+                "LanguageFilter: selected languages cover {:.0}% of segments; filtering all {} errors",
+                summary.selected_ratio(&self.excluded_languages) * 100.0,
+                errors.len()
             );
-
-            if ratio > NON_ENGLISH_THRESHOLD {
-                tracing::info!(
-                    "LanguageFilter: Document is primarily {:?} (>{:.0}%), filtering ALL {} errors",
-                    lang,
-                    NON_ENGLISH_THRESHOLD * 100.0,
-                    errors.len()
-                );
-                return vec![];
-            }
+            return vec![];
         }
 
-        // Fall back to sentence-level detection for mixed-language documents
-        let sentences = split_into_sentences(text);
-
-        // Detect language for each sentence (cache to avoid redundant detection)
-        // Use get() for safe slicing to avoid panics on invalid UTF-8 boundaries
-        let sentence_languages: Vec<(usize, usize, Lang)> = sentences
-            .iter()
-            .filter_map(|&(start, end)| {
-                // Safe slice - returns None if indices are not at valid UTF-8 boundaries
-                text.get(start..end).map(|sentence_text| {
-                    let lang = detect_language(sentence_text);
-                    (start, end, lang)
-                })
-            })
-            .collect();
-
-        // Filter errors based on sentence language
         errors
             .into_iter()
             .filter(|error| {
-                // Find which sentence this error belongs to
-                let sentence_lang = sentence_languages
-                    .iter()
-                    .find(|(start, end, _)| error.start >= *start && error.end <= *end)
-                    .map(|(_, _, lang)| lang);
+                let detected_segment = summary.segments.iter().find(|segment| {
+                    error.start >= segment.range.scalar_start
+                        && error.end <= segment.range.scalar_end
+                });
 
-                match sentence_lang {
-                    Some(lang) => {
-                        // Keep error if sentence is NOT in an excluded language
-                        !self.excluded_languages.contains(lang)
+                match detected_segment {
+                    Some(segment) => {
+                        let should_ignore = segment.reliable
+                            && segment.language.is_some_and(|language| {
+                                self.excluded_languages.contains(&language)
+                            });
+
+                        if should_ignore {
+                            tracing::debug!(
+                                "LanguageFilter: filtering error in language={:?}, confidence={:.2}",
+                                segment.language,
+                                segment.confidence
+                            );
+                        }
+
+                        !should_ignore
                     }
-                    None => {
-                        // If we can't find the sentence, keep the error (fail-safe)
-                        true
-                    }
+                    // If an error cannot be mapped to a segment, preserve it.
+                    None => true,
                 }
             })
             .collect()
     }
 
-    /// Check if document is primarily in a non-English language
-    ///
-    /// Returns true if:
-    /// - Language detection is enabled
-    /// - At least one language is excluded
-    /// - The document's dominant language is in the excluded list
-    /// - More than 60% of sentences are in that language
-    ///
-    /// This is used to skip readability analysis for non-English documents,
-    /// since Flesch Reading Ease is calibrated for English only.
+    /// Convenience path for focused tests and callers without a cached summary.
+    pub fn filter_errors(&self, errors: Vec<GrammarError>, text: &str) -> Vec<GrammarError> {
+        match self.analyze(text) {
+            Some(summary) => self.filter_errors_with_summary(errors, &summary),
+            None => errors,
+        }
+    }
+
+    /// Whether selected, reliable segments account for more than 60% of the document.
     pub fn is_document_primarily_non_english(&self, text: &str) -> bool {
-        // If detection is disabled or no excluded languages, assume English
-        if !self.enabled || self.excluded_languages.is_empty() {
-            return false;
-        }
-
-        // Check if document is primarily in an excluded language
-        if let Some((lang, ratio)) =
-            calculate_excluded_language_ratio(text, &self.excluded_languages)
-        {
-            tracing::debug!(
-                "LanguageFilter: Document language check - {:?} ({:.0}%), is_non_english={}",
-                lang,
-                ratio * 100.0,
-                ratio > NON_ENGLISH_THRESHOLD
-            );
-            return ratio > NON_ENGLISH_THRESHOLD;
-        }
-
-        false
+        self.analyze(text)
+            .is_some_and(|summary| self.should_skip_harper(&summary))
     }
 }
 
-/// Calculate the ratio of sentences in an excluded language.
-///
-/// Returns `Some((lang, ratio))` if the document's dominant language is in the excluded list,
-/// where `lang` is the detected language and `ratio` is the proportion of sentences in that language.
-/// Returns `None` if the document's dominant language is not in the excluded list.
-///
-/// This is the core logic shared by `filter_errors`, `is_document_primarily_non_english`,
-/// and `should_skip_harper_analysis`.
-fn calculate_excluded_language_ratio(
-    text: &str,
-    excluded_languages: &[Lang],
-) -> Option<(Lang, f64)> {
-    // Detect the dominant language of the document
-    let doc_lang = detect_language(text);
-
-    // If detected language is not in excluded list, return None
-    if !excluded_languages.contains(&doc_lang) {
-        return None;
+/// Accept the display names persisted by TextWarden versions before ISO-code storage.
+/// Swift migrates these values eagerly; this fallback keeps the FFI boundary safe
+/// during upgrades where an analysis request may race preference initialization.
+fn legacy_language_code(value: &str) -> Option<&'static str> {
+    match value.to_lowercase().as_str() {
+        "arabic" => Some("ara"),
+        "dutch" => Some("nld"),
+        "french" => Some("fra"),
+        "german" => Some("deu"),
+        "hindi" => Some("hin"),
+        "italian" => Some("ita"),
+        "japanese" => Some("jpn"),
+        "korean" => Some("kor"),
+        "mandarin" | "chinese" => Some("cmn"),
+        "portuguese" => Some("por"),
+        "russian" => Some("rus"),
+        "spanish" => Some("spa"),
+        "swedish" => Some("swe"),
+        "turkish" => Some("tur"),
+        "vietnamese" => Some("vie"),
+        _ => None,
     }
-
-    // Split into sentences and calculate ratio
-    let sentences = split_into_sentences(text);
-    if sentences.is_empty() {
-        return Some((doc_lang, 0.0));
-    }
-
-    let doc_lang_count = sentences
-        .iter()
-        .filter(|(s, e)| {
-            text.get(*s..*e)
-                .map(|t| detect_language(t) == doc_lang)
-                .unwrap_or(false)
-        })
-        .count();
-
-    let ratio = doc_lang_count as f64 / sentences.len() as f64;
-    Some((doc_lang, ratio))
 }
 
 /// Split text into sentences/segments for language detection
 /// Handles: punctuation (.!?), paragraph breaks, bullet points, numbered lists
 /// Returns a vector of (start, end) byte positions for each segment
 pub fn split_into_sentences(text: &str) -> Vec<(usize, usize)> {
+    split_into_byte_ranges(text)
+}
+
+fn split_into_segments(text: &str) -> Vec<SegmentRange> {
+    let scalar_boundaries: Vec<usize> = text
+        .char_indices()
+        .map(|(byte_index, _)| byte_index)
+        .chain(std::iter::once(text.len()))
+        .collect();
+
+    split_into_byte_ranges(text)
+        .into_iter()
+        .filter(|(byte_start, byte_end)| {
+            text.get(*byte_start..*byte_end)
+                .is_some_and(|segment| !segment.trim().is_empty())
+        })
+        .filter_map(|(byte_start, byte_end)| {
+            let scalar_start = scalar_boundaries.binary_search(&byte_start).ok()?;
+            let scalar_end = scalar_boundaries.binary_search(&byte_end).ok()?;
+            Some(SegmentRange {
+                byte_start,
+                byte_end,
+                scalar_start,
+                scalar_end,
+            })
+        })
+        .collect()
+}
+
+fn split_into_byte_ranges(text: &str) -> Vec<(usize, usize)> {
     let mut sentences = Vec::new();
     let mut start = 0;
     let mut i = 0;
@@ -377,48 +424,9 @@ pub fn should_skip_harper_analysis(
     enabled: bool,
     excluded_languages: &[String],
 ) -> Option<bool> {
-    // Disabled or no exclusions - can't make a determination
-    if !enabled || excluded_languages.is_empty() {
-        return None;
-    }
-
-    // Convert language strings to Lang enums
-    let langs: Vec<Lang> = excluded_languages
-        .iter()
-        .filter_map(|s| lang_from_string(s))
-        .collect();
-
-    if langs.is_empty() {
-        return None;
-    }
-
-    // Use shared logic to calculate excluded language ratio
-    match calculate_excluded_language_ratio(text, &langs) {
-        Some((_, ratio)) => Some(ratio > NON_ENGLISH_THRESHOLD),
-        None => Some(false), // Document language not in excluded list
-    }
-}
-
-/// Convert language string to whichlang Lang enum
-pub fn lang_from_string(s: &str) -> Option<Lang> {
-    match s.to_lowercase().as_str() {
-        "spanish" | "spa" => Some(Lang::Spa),
-        "french" | "fra" | "fre" => Some(Lang::Fra),
-        "german" | "deu" | "ger" => Some(Lang::Deu),
-        "italian" | "ita" => Some(Lang::Ita),
-        "portuguese" | "por" => Some(Lang::Por),
-        "dutch" | "nld" | "dut" => Some(Lang::Nld),
-        "russian" | "rus" => Some(Lang::Rus),
-        "chinese" | "mandarin" | "cmn" => Some(Lang::Cmn),
-        "japanese" | "jpn" => Some(Lang::Jpn),
-        "korean" | "kor" => Some(Lang::Kor),
-        "arabic" | "ara" => Some(Lang::Ara),
-        "hindi" | "hin" => Some(Lang::Hin),
-        "turkish" | "tur" => Some(Lang::Tur),
-        "swedish" | "swe" => Some(Lang::Swe),
-        "vietnamese" | "vie" => Some(Lang::Vie),
-        _ => None,
-    }
+    let filter = LanguageFilter::new(enabled, excluded_languages.to_vec());
+    let summary = filter.analyze(text)?;
+    Some(filter.should_skip_harper(&summary))
 }
 
 #[cfg(test)]
@@ -435,6 +443,43 @@ mod tests {
             category: "Spelling".to_string(),
             lint_id: "test".to_string(),
             suggestions: vec![],
+        }
+    }
+
+    const ENGLISH_SENTENCE: &str = "This is a detailed English sentence with enough characteristic words for automatic language detection to produce a useful and dependable result.";
+    const GERMAN_SENTENCE: &str = "Dies ist ein ausführlicher deutscher Satz mit genügend charakteristischen Wörtern, damit die automatische Spracherkennung zuverlässig funktioniert.";
+    const SPANISH_SENTENCE: &str = "Esta es una oración española detallada con suficientes palabras características para que la detección automática del idioma funcione de manera fiable.";
+    const FRENCH_SENTENCE: &str = "Ceci est une phrase française détaillée qui contient suffisamment de mots caractéristiques pour que la détection automatique de la langue fonctionne correctement.";
+
+    fn error_for(text: &str, needle: &str) -> GrammarError {
+        let byte_start = text
+            .find(needle)
+            .expect("test fixture should contain needle");
+        let scalar_start = text[..byte_start].chars().count();
+        create_error(
+            scalar_start,
+            scalar_start + needle.chars().count(),
+            "Unknown word",
+        )
+    }
+
+    fn synthetic_summary(detections: &[(Option<Lang>, bool)]) -> LanguageDetectionSummary {
+        LanguageDetectionSummary {
+            segments: detections
+                .iter()
+                .enumerate()
+                .map(|(index, (language, reliable))| DetectedSegment {
+                    range: SegmentRange {
+                        byte_start: index,
+                        byte_end: index + 1,
+                        scalar_start: index,
+                        scalar_end: index + 1,
+                    },
+                    language: *language,
+                    confidence: if *reliable { 1.0 } else { 0.5 },
+                    reliable: *reliable,
+                })
+                .collect(),
         }
     }
 
@@ -534,6 +579,17 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_split_crlf_paragraphs_and_list_items() {
+        let text = "First paragraph\r\n\r\n- Second item\r\n- Third item";
+        let sentences = split_into_sentences(text);
+
+        assert_eq!(sentences.len(), 3);
+        assert_eq!(&text[sentences[0].0..sentences[0].1], "First paragraph\r");
+        assert_eq!(&text[sentences[1].0..sentences[1].1], "- Second item\r\n");
+        assert_eq!(&text[sentences[2].0..sentences[2].1], "- Third item");
+    }
+
     // MARK: - Basic Filtering Tests
 
     #[test]
@@ -564,14 +620,10 @@ mod tests {
 
     #[test]
     fn test_single_german_sentence_filtered() {
-        let filter = LanguageFilter::new(true, vec!["german".to_string()]);
-        let text = "Hallo Welt, wie geht es dir?";
-        let errors = vec![
-            create_error(0, 5, "Unknown word"),   // Hallo
-            create_error(11, 14, "Unknown word"), // wie
-        ];
+        let filter = LanguageFilter::new(true, vec!["deu".to_string()]);
+        let errors = vec![error_for(GERMAN_SENTENCE, "ausführlicher")];
 
-        let filtered = filter.filter_errors(errors, text);
+        let filtered = filter.filter_errors(errors, GERMAN_SENTENCE);
         assert_eq!(
             filtered.len(),
             0,
@@ -598,14 +650,10 @@ mod tests {
 
     #[test]
     fn test_single_spanish_sentence() {
-        let filter = LanguageFilter::new(true, vec!["spanish".to_string()]);
-        let text = "Hola amigos, como estas?";
-        let errors = vec![
-            create_error(0, 4, "Unknown word"),   // Hola
-            create_error(13, 17, "Unknown word"), // como
-        ];
+        let filter = LanguageFilter::new(true, vec!["spa".to_string()]);
+        let errors = vec![error_for(SPANISH_SENTENCE, "española")];
 
-        let filtered = filter.filter_errors(errors, text);
+        let filtered = filter.filter_errors(errors, SPANISH_SENTENCE);
         assert_eq!(
             filtered.len(),
             0,
@@ -615,14 +663,10 @@ mod tests {
 
     #[test]
     fn test_single_french_sentence() {
-        let filter = LanguageFilter::new(true, vec!["french".to_string()]);
-        let text = "Bonjour mes amis, comment allez-vous?";
-        let errors = vec![
-            create_error(0, 7, "Unknown word"),   // Bonjour
-            create_error(18, 25, "Unknown word"), // comment
-        ];
+        let filter = LanguageFilter::new(true, vec!["fra".to_string()]);
+        let errors = vec![error_for(FRENCH_SENTENCE, "française")];
 
-        let filtered = filter.filter_errors(errors, text);
+        let filtered = filter.filter_errors(errors, FRENCH_SENTENCE);
         assert_eq!(
             filtered.len(),
             0,
@@ -633,9 +677,8 @@ mod tests {
     // MARK: - Multi-Sentence Tests (User Example!)
 
     #[test]
-    fn test_user_example_mixed_sentences() {
-        // Your exact example: "Hello dear Nachbar, how are you doing? Gruss Bob"
-        let filter = LanguageFilter::new(true, vec!["german".to_string()]);
+    fn test_short_ambiguous_segments_fail_open() {
+        let filter = LanguageFilter::new(true, vec!["deu".to_string()]);
         let text = "Hello dear Nachbar, how are you doing? Gruss Bob";
         let errors = vec![
             create_error(11, 18, "Unknown word"), // Nachbar (in English sentence)
@@ -644,52 +687,42 @@ mod tests {
 
         let filtered = filter.filter_errors(errors, text);
 
-        // First sentence "Hello dear Nachbar, how are you doing?" is English -> keep errors
-        // Second sentence "Gruss Bob" is German -> filter errors
         assert_eq!(
             filtered.len(),
-            1,
-            "Should keep English sentence error, filter German sentence error"
+            2,
+            "Short ambiguous segments should remain checked"
         );
-
-        // Verify the kept error is from the English sentence
-        assert_eq!(filtered[0].start, 11);
-        assert_eq!(filtered[0].end, 18);
     }
 
     #[test]
     fn test_mixed_english_german_sentences() {
-        let filter = LanguageFilter::new(true, vec!["german".to_string()]);
-        let text = "This is English. Das ist Deutsch. More English here.";
+        let filter = LanguageFilter::new(true, vec!["deu".to_string()]);
+        let text = format!("{ENGLISH_SENTENCE} {GERMAN_SENTENCE} {ENGLISH_SENTENCE}");
         let errors = vec![
-            create_error(5, 7, "Error 1"),   // "is" in English sentence
-            create_error(21, 23, "Error 2"), // "ist" in German sentence
-            create_error(44, 48, "Error 3"), // "here" in English sentence
+            error_for(&text, "detailed"),
+            error_for(&text, "ausführlicher"),
         ];
 
-        let filtered = filter.filter_errors(errors, text);
+        let filtered = filter.filter_errors(errors, &text);
 
         // Should keep errors from English sentences, filter from German
-        assert_eq!(filtered.len(), 2, "Should keep English sentence errors");
-        assert_eq!(filtered[0].start, 5); // First English error
-        assert_eq!(filtered[1].start, 44); // Second English error
+        assert_eq!(filtered.len(), 1, "Should keep the English sentence error");
     }
 
     #[test]
     fn test_mixed_english_spanish_french() {
-        let filter = LanguageFilter::new(true, vec!["spanish".to_string(), "french".to_string()]);
-        let text = "Hello. Hola amigos. Bonjour. Goodbye.";
+        let filter = LanguageFilter::new(true, vec!["spa".to_string(), "fra".to_string()]);
+        let text =
+            format!("{ENGLISH_SENTENCE} {SPANISH_SENTENCE} {FRENCH_SENTENCE} {ENGLISH_SENTENCE}");
         let errors = vec![
-            create_error(0, 5, "Error"),   // Hello (English)
-            create_error(7, 11, "Error"),  // Hola (Spanish)
-            create_error(20, 27, "Error"), // Bonjour (French)
-            create_error(29, 36, "Error"), // Goodbye (English)
+            error_for(&text, "detailed"),
+            error_for(&text, "española"),
+            error_for(&text, "française"),
         ];
 
-        let filtered = filter.filter_errors(errors, text);
+        let filtered = filter.filter_errors(errors, &text);
 
-        // Should keep English errors, filter Spanish and French
-        assert_eq!(filtered.len(), 2, "Should keep only English errors");
+        assert_eq!(filtered.len(), 1, "Should keep only the English error");
     }
 
     // MARK: - Performance Tests
@@ -750,15 +783,15 @@ mod tests {
     #[test]
     fn test_selective_language_exclusion() {
         // Only Spanish excluded, not German
-        let filter = LanguageFilter::new(true, vec!["spanish".to_string()]);
-        let text = "Hola amigos. Hallo Welt. Hello world.";
+        let filter = LanguageFilter::new(true, vec!["spa".to_string()]);
+        let text = format!("{SPANISH_SENTENCE} {GERMAN_SENTENCE} {ENGLISH_SENTENCE}");
         let errors = vec![
-            create_error(0, 4, "Error 1"),   // Hola (Spanish sentence)
-            create_error(13, 18, "Error 2"), // Hallo (German sentence)
-            create_error(25, 30, "Error 3"), // Hello (English sentence)
+            error_for(&text, "española"),
+            error_for(&text, "ausführlicher"),
+            error_for(&text, "detailed"),
         ];
 
-        let filtered = filter.filter_errors(errors, text);
+        let filtered = filter.filter_errors(errors, &text);
 
         // Spanish sentence filtered, German and English kept
         assert_eq!(filtered.len(), 2);
@@ -768,27 +801,26 @@ mod tests {
     fn test_multiple_excluded_languages() {
         let filter = LanguageFilter::new(
             true,
-            vec![
-                "german".to_string(),
-                "spanish".to_string(),
-                "french".to_string(),
-            ],
+            vec!["deu".to_string(), "spa".to_string(), "fra".to_string()],
         );
-        // Use longer sentences to provide enough context for accurate language detection
-        let text =
-            "This is English. Das ist Deutsch. Esto es Español. C'est Français. More English here.";
+        // Three of five reliable segments are selected: exactly 60% must not
+        // trigger the whole-document bailout.
+        let text = format!(
+            "{ENGLISH_SENTENCE} {GERMAN_SENTENCE} {SPANISH_SENTENCE} {FRENCH_SENTENCE} {ENGLISH_SENTENCE}"
+        );
         let errors = vec![
-            create_error(0, 7, "E1"),   // "This is" in English sentence
-            create_error(21, 24, "E2"), // "ist" in German sentence
-            create_error(38, 40, "E3"), // "es" in Spanish sentence
-            create_error(58, 64, "E4"), // "C'est" in French sentence
-            create_error(71, 75, "E5"), // "More" in English sentence
+            error_for(&text, "detailed"),
+            error_for(&text, "ausführlicher"),
+            error_for(&text, "española"),
+            error_for(&text, "française"),
         ];
 
-        let filtered = filter.filter_errors(errors, text);
+        let summary = filter.analyze(&text).expect("language detection enabled");
+        assert!(!filter.should_skip_harper(&summary));
 
-        // Should keep only English sentence errors (E1 and E5)
-        assert_eq!(filtered.len(), 2);
+        let filtered = filter.filter_errors_with_summary(errors, &summary);
+
+        assert_eq!(filtered.len(), 1);
     }
 
     // MARK: - Document Language Detection Tests (for readability skip)
@@ -821,22 +853,22 @@ mod tests {
 
     #[test]
     fn test_is_non_english_english_document() {
-        let filter = LanguageFilter::new(true, vec!["german".to_string()]);
-        let english_text = "This is a long English document. It contains several sentences. The language is English. We want to make sure readability works here.";
+        let filter = LanguageFilter::new(true, vec!["deu".to_string()]);
+        let english_text = format!("{0} {0} {0}", ENGLISH_SENTENCE);
 
         assert!(
-            !filter.is_document_primarily_non_english(english_text),
+            !filter.is_document_primarily_non_english(&english_text),
             "English document should not be detected as non-English"
         );
     }
 
     #[test]
     fn test_is_non_english_german_document() {
-        let filter = LanguageFilter::new(true, vec!["german".to_string()]);
-        let german_text = "Das ist ein langer deutscher Text. Er enthält mehrere Sätze. Die Sprache ist Deutsch. Wir wollen sicherstellen, dass die Erkennung funktioniert.";
+        let filter = LanguageFilter::new(true, vec!["deu".to_string()]);
+        let german_text = format!("{0} {0} {0}", GERMAN_SENTENCE);
 
         assert!(
-            filter.is_document_primarily_non_english(german_text),
+            filter.is_document_primarily_non_english(&german_text),
             "German document should be detected as non-English when German is excluded"
         );
     }
@@ -844,12 +876,11 @@ mod tests {
     #[test]
     fn test_is_non_english_german_not_in_excluded() {
         // German document but German is not in excluded list
-        let filter = LanguageFilter::new(true, vec!["spanish".to_string()]);
-        let german_text =
-            "Das ist ein langer deutscher Text. Er enthält mehrere Sätze. Die Sprache ist Deutsch.";
+        let filter = LanguageFilter::new(true, vec!["spa".to_string()]);
+        let german_text = format!("{0} {0} {0}", GERMAN_SENTENCE);
 
         assert!(
-            !filter.is_document_primarily_non_english(german_text),
+            !filter.is_document_primarily_non_english(&german_text),
             "German document should not be flagged when German is not excluded"
         );
     }
@@ -857,33 +888,35 @@ mod tests {
     #[test]
     fn test_is_non_english_mixed_document() {
         // Mixed document with <60% German - should not be flagged
-        let filter = LanguageFilter::new(true, vec!["german".to_string()]);
-        let mixed_text = "This is English. Hello world. How are you today? Das ist Deutsch. This is more English text.";
+        let filter = LanguageFilter::new(true, vec!["deu".to_string()]);
+        let mixed_text = format!(
+            "{ENGLISH_SENTENCE} {ENGLISH_SENTENCE} {ENGLISH_SENTENCE} {GERMAN_SENTENCE} {GERMAN_SENTENCE}"
+        );
 
         assert!(
-            !filter.is_document_primarily_non_english(mixed_text),
+            !filter.is_document_primarily_non_english(&mixed_text),
             "Mixed document with <60% German should not be flagged as non-English"
         );
     }
 
     #[test]
     fn test_is_non_english_spanish_document() {
-        let filter = LanguageFilter::new(true, vec!["spanish".to_string()]);
-        let spanish_text = "Este es un documento en español. Contiene varias oraciones. El idioma es español. Queremos asegurarnos de que la detección funcione correctamente.";
+        let filter = LanguageFilter::new(true, vec!["spa".to_string()]);
+        let spanish_text = format!("{0} {0} {0}", SPANISH_SENTENCE);
 
         assert!(
-            filter.is_document_primarily_non_english(spanish_text),
+            filter.is_document_primarily_non_english(&spanish_text),
             "Spanish document should be detected as non-English when Spanish is excluded"
         );
     }
 
     #[test]
     fn test_is_non_english_french_document() {
-        let filter = LanguageFilter::new(true, vec!["french".to_string()]);
-        let french_text = "Ceci est un long document en français. Il contient plusieurs phrases. La langue est le français. Nous voulons nous assurer que la détection fonctionne.";
+        let filter = LanguageFilter::new(true, vec!["fra".to_string()]);
+        let french_text = format!("{0} {0} {0}", FRENCH_SENTENCE);
 
         assert!(
-            filter.is_document_primarily_non_english(french_text),
+            filter.is_document_primarily_non_english(&french_text),
             "French document should be detected as non-English when French is excluded"
         );
     }
@@ -939,11 +972,8 @@ mod tests {
     #[test]
     fn test_should_skip_harper_german_document() {
         // German document (>60% German) should be skipped
-        let result = should_skip_harper_analysis(
-            "Das ist ein langer deutscher Text. Er enthält mehrere Sätze. Die Sprache ist Deutsch. Wir wollen sicherstellen, dass die Erkennung funktioniert.",
-            true,
-            &["german".to_string()],
-        );
+        let german_text = format!("{0} {0} {0}", GERMAN_SENTENCE);
+        let result = should_skip_harper_analysis(&german_text, true, &["deu".to_string()]);
         assert_eq!(
             result,
             Some(true),
@@ -954,11 +984,10 @@ mod tests {
     #[test]
     fn test_should_skip_harper_mixed_document() {
         // Mixed document with <60% German should not be skipped
-        let result = should_skip_harper_analysis(
-            "This is English. Hello world. How are you today? Das ist Deutsch. This is more English text.",
-            true,
-            &["german".to_string()],
+        let mixed_text = format!(
+            "{ENGLISH_SENTENCE} {ENGLISH_SENTENCE} {ENGLISH_SENTENCE} {GERMAN_SENTENCE} {GERMAN_SENTENCE}"
         );
+        let result = should_skip_harper_analysis(&mixed_text, true, &["deu".to_string()]);
         assert_eq!(
             result,
             Some(false),
@@ -969,11 +998,8 @@ mod tests {
     #[test]
     fn test_should_skip_harper_wrong_excluded_language() {
         // German document but only Spanish is excluded - should not skip
-        let result = should_skip_harper_analysis(
-            "Das ist ein langer deutscher Text. Er enthält mehrere Sätze.",
-            true,
-            &["spanish".to_string()],
-        );
+        let german_text = format!("{0} {0} {0}", GERMAN_SENTENCE);
+        let result = should_skip_harper_analysis(&german_text, true, &["spa".to_string()]);
         assert_eq!(
             result,
             Some(false),
@@ -985,5 +1011,244 @@ mod tests {
     fn test_should_skip_harper_empty_text() {
         let result = should_skip_harper_analysis("", true, &["german".to_string()]);
         assert_eq!(result, Some(false), "Empty text should return Some(false)");
+    }
+
+    #[test]
+    fn test_latvian_issue_samples_are_reliably_filtered() {
+        let filter = LanguageFilter::new(true, vec!["lav".to_string()]);
+        let samples = [
+            "Šodien ir silta diena un es rakstu vēstuli.",
+            "Latviešu valoda ir skaista un bagāta valoda, kurā runā Latvijā.",
+        ];
+
+        for text in samples {
+            let summary = filter.analyze(text).expect("language detection enabled");
+            let segment = summary.segments.first().expect("one Latvian segment");
+            assert_eq!(segment.language, Some(Lang::Lav));
+            assert!(segment.reliable);
+
+            let errors = vec![error_for(text, text.split_whitespace().next().unwrap())];
+            assert!(filter
+                .filter_errors_with_summary(errors, &summary)
+                .is_empty());
+        }
+    }
+
+    #[test]
+    fn test_existing_language_catalog_samples_are_reliable() {
+        let samples = [
+            (Lang::Ara, "اللغة العربية لغة جميلة وغنية، ويتحدث بها ملايين الناس في بلدان عديدة حول العالم كل يوم."),
+            (Lang::Nld, "Dit is een uitgebreide Nederlandse zin met voldoende kenmerkende woorden om de automatische taalherkenning betrouwbaar te laten werken."),
+            (Lang::Eng, ENGLISH_SENTENCE),
+            (Lang::Fra, FRENCH_SENTENCE),
+            (Lang::Deu, GERMAN_SENTENCE),
+            (Lang::Hin, "हिन्दी भारत में व्यापक रूप से बोली जाने वाली एक समृद्ध भाषा है और इसकी साहित्यिक परंपरा बहुत पुरानी है।"),
+            (Lang::Ita, "Questa è una frase italiana dettagliata con abbastanza parole caratteristiche perché il rilevamento automatico della lingua funzioni in modo affidabile."),
+            (Lang::Jpn, "日本語は日本で広く話されている言語であり、豊かな文学と長い文化的な歴史を持っています。"),
+            (Lang::Kor, "한국어는 대한민국에서 널리 사용되는 언어이며 풍부한 문학과 오랜 문화적 역사를 가지고 있습니다."),
+            (Lang::Cmn, "中文是一种历史悠久而且内容丰富的语言，世界各地有许多人每天使用中文进行交流和学习。"),
+            (Lang::Por, "Esta é uma frase portuguesa detalhada com palavras características suficientes para que a detecção automática do idioma funcione de forma confiável."),
+            (Lang::Rus, "Русский язык обладает богатой литературной традицией, и миллионы людей используют его для общения каждый день."),
+            (Lang::Spa, SPANISH_SENTENCE),
+            (Lang::Swe, "Det här är en detaljerad svensk mening med tillräckligt många karakteristiska ord för att den automatiska språkidentifieringen ska fungera tillförlitligt."),
+            (Lang::Tur, "Bu, otomatik dil algılamanın güvenilir bir şekilde çalışması için yeterli karakteristik kelime içeren ayrıntılı bir Türkçe cümledir."),
+            (Lang::Vie, "Tiếng Việt là một ngôn ngữ phong phú với lịch sử lâu đời và được hàng triệu người sử dụng để giao tiếp mỗi ngày."),
+        ];
+
+        for (expected, text) in samples {
+            let summary = LanguageDetectionSummary::detect(text);
+            let segment = summary.segments.first().expect("one language segment");
+            assert_eq!(
+                segment.language,
+                Some(expected),
+                "unexpected language for {text}"
+            );
+            assert!(segment.reliable, "unreliable language for {text}");
+        }
+    }
+
+    #[test]
+    fn test_baltic_and_nordic_samples_do_not_confuse_neighboring_languages() {
+        let samples = [
+            (Lang::Lav, true, "Latviešu valoda ir bagāta un skaista, un Latvijā cilvēki to lieto ikdienas sarunās, skolās un literatūrā."),
+            (Lang::Lit, true, "Lietuvių kalba yra turtinga ir graži, o Lietuvoje žmonės ją kasdien vartoja pokalbiuose, mokyklose ir literatūroje."),
+            (Lang::Est, true, "Eesti keel on rikkalik ja kaunis ning Eestis kasutatakse seda iga päev vestlustes, koolides ja kirjanduses."),
+            (Lang::Fin, true, "Suomen kieli on rikas ja kaunis, ja Suomessa ihmiset käyttävät sitä päivittäin keskusteluissa, kouluissa ja kirjallisuudessa."),
+            (Lang::Swe, true, "Svenska språket är rikt och vackert, och i Sverige använder människor det varje dag i samtal, skolor och litteratur."),
+            (Lang::Dan, false, "Jeg synes, at det danske sprog er meget smukt, fordi ordene lyder hyggelige, når mennesker taler sammen, og børnene lærer at læse og skrive i skolen, mens familierne bruger sproget derhjemme hver eneste dag."),
+            (Lang::Nob, false, "Det norske språket er rikt og vakkert, og i Norge bruker mennesker det hver dag i samtaler, skoler og litteratur."),
+        ];
+
+        for (expected, should_be_reliable, text) in samples {
+            let summary = LanguageDetectionSummary::detect(text);
+            let segment = summary.segments.first().expect("one language segment");
+            assert_eq!(
+                segment.language,
+                Some(expected),
+                "unexpected language for {text}"
+            );
+            assert_eq!(
+                segment.reliable, should_be_reliable,
+                "unexpected reliability for {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_unreliable_danish_norwegian_confusion_fails_open() {
+        let text = "Jeg synes, at det danske sprog er meget smukt, fordi ordene lyder hyggelige, når mennesker taler sammen, og børnene lærer at læse og skrive i skolen, mens familierne bruger sproget derhjemme hver eneste dag.";
+        let filter = LanguageFilter::new(true, vec!["dan".to_string()]);
+        let summary = filter.analyze(text).expect("language detection enabled");
+        let segment = summary.segments.first().expect("one language segment");
+
+        assert_eq!(segment.language, Some(Lang::Dan));
+        assert!(!segment.reliable);
+        assert_eq!(
+            filter
+                .filter_errors_with_summary(vec![error_for(text, "danske")], &summary)
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_unselected_latvian_remains_checked() {
+        let text = "Šodien ir silta diena un es rakstu vēstuli.";
+        let filter = LanguageFilter::new(true, vec!["lit".to_string()]);
+        let errors = vec![error_for(text, "Šodien")];
+
+        assert_eq!(filter.filter_errors(errors, text).len(), 1);
+    }
+
+    #[test]
+    fn test_multibyte_ranges_map_to_harper_scalar_offsets() {
+        let text = format!("👋 Šodien ir silta diena un es rakstu vēstuli. {ENGLISH_SENTENCE}");
+        let filter = LanguageFilter::new(true, vec!["lav".to_string()]);
+        let latvian_error = error_for(&text, "vēstuli");
+        let english_error = error_for(&text, "detailed");
+        let expected_english_start = english_error.start;
+
+        let filtered = filter.filter_errors(vec![latvian_error, english_error], &text);
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].start, expected_english_start);
+    }
+
+    #[test]
+    fn test_cjk_and_crlf_ranges_map_to_harper_scalar_offsets() {
+        let chinese = "中文是一种历史悠久而且内容丰富的语言，许多人每天使用中文进行交流?";
+        let text = format!("{chinese}\r\n\r\n{ENGLISH_SENTENCE}");
+        let filter = LanguageFilter::new(true, vec!["cmn".to_string()]);
+        let chinese_error = error_for(&text, "历史悠久");
+        let english_error = error_for(&text, "detailed");
+        let expected_english_start = english_error.start;
+
+        let filtered = filter.filter_errors(vec![chinese_error, english_error], &text);
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].start, expected_english_start);
+    }
+
+    #[test]
+    fn test_exactly_sixty_percent_selected_does_not_skip() {
+        let filter = LanguageFilter::new(true, vec!["lav".to_string()]);
+        let summary = synthetic_summary(&[
+            (Some(Lang::Lav), true),
+            (Some(Lang::Lav), true),
+            (Some(Lang::Lav), true),
+            (Some(Lang::Eng), true),
+            (Some(Lang::Eng), true),
+        ]);
+
+        assert_eq!(summary.selected_ratio(&filter.excluded_languages), 0.6);
+        assert!(!filter.should_skip_harper(&summary));
+    }
+
+    #[test]
+    fn test_multiple_selected_languages_can_trigger_document_skip() {
+        let filter = LanguageFilter::new(true, vec!["lav".to_string(), "fra".to_string()]);
+        let summary = synthetic_summary(&[
+            (Some(Lang::Lav), true),
+            (Some(Lang::Lav), true),
+            (Some(Lang::Fra), true),
+            (Some(Lang::Fra), true),
+            (Some(Lang::Eng), true),
+        ]);
+
+        assert!(filter.should_skip_harper(&summary));
+    }
+
+    #[test]
+    fn test_unreliable_segments_remain_in_ratio_denominator() {
+        let filter = LanguageFilter::new(true, vec!["lav".to_string()]);
+        let summary = synthetic_summary(&[
+            (Some(Lang::Lav), true),
+            (Some(Lang::Lav), true),
+            (Some(Lang::Lav), true),
+            (Some(Lang::Lav), false),
+            (None, false),
+        ]);
+
+        assert_eq!(summary.selected_ratio(&filter.excluded_languages), 0.6);
+        assert!(!filter.should_skip_harper(&summary));
+    }
+
+    #[test]
+    fn test_all_non_english_languages_can_be_selected() {
+        let codes = Lang::all()
+            .iter()
+            .filter(|language| **language != Lang::Eng)
+            .map(|language| language.code().to_string())
+            .collect();
+        let filter = LanguageFilter::new(true, codes);
+
+        assert_eq!(filter.excluded_language_count(), 69);
+    }
+
+    #[test]
+    #[ignore]
+    fn test_performance_whatlang_detection_profiles() {
+        use std::hint::black_box;
+        use std::time::Instant;
+
+        let short = "Šodien ir silta diena un es rakstu vēstuli.";
+        let document = ENGLISH_SENTENCE.repeat(34);
+        let mixed_segments = (0..100)
+            .map(|index| match index % 4 {
+                0 => format!("- {ENGLISH_SENTENCE}"),
+                1 => format!("- {GERMAN_SENTENCE}"),
+                2 => format!("- {SPANISH_SENTENCE}"),
+                _ => format!("- {FRENCH_SENTENCE}"),
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        fn average_micros(text: &str, iterations: u32) -> u128 {
+            let start = Instant::now();
+            for _ in 0..iterations {
+                black_box(LanguageDetectionSummary::detect(black_box(text)));
+            }
+            start.elapsed().as_micros() / u128::from(iterations)
+        }
+
+        black_box(LanguageDetectionSummary::detect(short));
+        let short_micros = average_micros(short, 1_000);
+        let document_micros = average_micros(&document, 200);
+        let mixed_micros = average_micros(&mixed_segments, 100);
+
+        println!("short segment: {short_micros} µs");
+        println!(
+            "4–5 KB document ({} bytes): {document_micros} µs",
+            document.len()
+        );
+        println!(
+            "mixed document ({} segments, {} bytes): {mixed_micros} µs",
+            split_into_segments(&mixed_segments).len(),
+            mixed_segments.len()
+        );
+
+        assert!(short_micros < 1_000);
+        assert!(document_micros < 10_000);
+        assert!(mixed_micros < 20_000);
     }
 }

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ TextWarden is a free, open-source grammar checker and writing assistant for macO
 - One-click corrections and a **Fix All** command for clear-cut errors
 - American, British, Canadian, Australian, and Indian English dialects
 - Custom vocabulary, the macOS learned-word dictionary, and optional word lists for technical terms, names, brands, abbreviations, and slang
-- Optional detection of selected non-English languages to avoid false positives in multilingual documents
+- Optional detection of 69 selectable non-English languages to avoid false positives in multilingual documents
 - Readability scores and sentence-complexity underlines for text with at least 30 words
 - Per-app pause controls, per-app underline controls, and website exclusions
 - A built-in Sketch Pad for focused drafting and revision
@@ -73,7 +73,7 @@ See the [Configuration Guide](CONFIGURATION.md) for every setting and the [Troub
 
 ## How It Works
 
-After you grant permission, TextWarden reads the text field you are typing in and checks it locally with the bundled Harper grammar checker. Suggestions appear as underlines or in a small floating indicator beside the app.
+After you grant permission, TextWarden reads the text field you are typing in and checks it locally with the bundled Harper grammar checker. Suggestions appear as underlines or in a small floating indicator beside the app. If you enable **Ignore selected languages**, TextWarden uses local language detection to skip English grammar checks only in passages it identifies confidently as one of your selected languages.
 
 When Apple Intelligence features are enabled, TextWarden gives the current text or selection to Apple's on-device AI. TextWarden does not operate a grammar or AI server.
 
@@ -127,7 +127,7 @@ Logs can contain parts of your writing, especially with Debug or Trace logging e
 
 ## Known Limitations
 
-- Grammar checking is English-only. Language detection suppresses checks for selected non-English languages; it does not proofread those languages.
+- Grammar checking is English-only. Language detection can suppress checks for 69 selected non-English languages, but it does not proofread or translate them. Very short or ambiguous passages remain checked when detection is uncertain.
 - Some custom text editors do not give macOS enough information for accurate underlines or safe corrections.
 - A correction can remove formatting in apps that only let TextWarden replace the entire text field.
 - Apple Intelligence style and composition features are unavailable on Intel Macs and on macOS releases before 26.
@@ -145,7 +145,7 @@ Logs can contain parts of your writing, especially with Debug or Trace logging e
 
 ## Credits
 
-TextWarden uses [Harper](https://github.com/Automattic/harper), an open-source English grammar checker written in Rust. It also depends on [swift-bridge](https://github.com/chinedufn/swift-bridge), [whichlang](https://github.com/quickwit-oss/whichlang), [KeyboardShortcuts](https://github.com/sindresorhus/KeyboardShortcuts), [LaunchAtLogin-Modern](https://github.com/sindresorhus/LaunchAtLogin-Modern), [Sparkle](https://sparkle-project.org), [swift-markdown](https://github.com/apple/swift-markdown), [STTextView](https://github.com/krzyzanowskim/STTextView), and [ConfettiSwiftUI](https://github.com/simibac/ConfettiSwiftUI).
+TextWarden uses [Harper](https://github.com/Automattic/harper), an open-source English grammar checker written in Rust. It also depends on [swift-bridge](https://github.com/chinedufn/swift-bridge), [Whatlang](https://github.com/greyblake/whatlang-rs), [KeyboardShortcuts](https://github.com/sindresorhus/KeyboardShortcuts), [LaunchAtLogin-Modern](https://github.com/sindresorhus/LaunchAtLogin-Modern), [Sparkle](https://sparkle-project.org), [swift-markdown](https://github.com/apple/swift-markdown), [STTextView](https://github.com/krzyzanowskim/STTextView), and [ConfettiSwiftUI](https://github.com/simibac/ConfettiSwiftUI).
 
 The codebase was developed with substantial AI assistance and human review. The TextWarden logo was created with [Recraft](https://www.recraft.ai/).
 

--- a/Sources/App/AnalysisCoordinator+GrammarAnalysis.swift
+++ b/Sources/App/AnalysisCoordinator+GrammarAnalysis.swift
@@ -77,7 +77,7 @@ extension AnalysisCoordinator {
             enablePersonNames: userPreferences.enablePersonNames,
             enableLastNames: userPreferences.enableLastNames,
             enableLanguageDetection: userPreferences.enableLanguageDetection,
-            excludedLanguages: Array(userPreferences.excludedLanguages.map { UserPreferences.languageCode(for: $0) }),
+            excludedLanguages: Array(userPreferences.excludedLanguages),
             enforceOxfordComma: userPreferences.enforceOxfordComma,
             checkEllipsis: userPreferences.checkEllipsis,
             checkUnclosedQuotes: userPreferences.checkUnclosedQuotes,
@@ -195,7 +195,7 @@ extension AnalysisCoordinator {
         let enablePersonNames = userPreferences.enablePersonNames
         let enableLastNames = userPreferences.enableLastNames
         let enableLanguageDetection = userPreferences.enableLanguageDetection
-        let excludedLanguages = Array(userPreferences.excludedLanguages.map { UserPreferences.languageCode(for: $0) })
+        let excludedLanguages = Array(userPreferences.excludedLanguages)
         let enforceOxfordComma = userPreferences.enforceOxfordComma
         let checkEllipsis = userPreferences.checkEllipsis
         let checkUnclosedQuotes = userPreferences.checkUnclosedQuotes

--- a/Sources/App/Dependencies.swift
+++ b/Sources/App/Dependencies.swift
@@ -104,7 +104,6 @@ protocol UserPreferencesProviding: AnyObject {
     func isEnabled(forURL url: URL) -> Bool
     func ignoreErrorText(_ text: String)
     func ignoreRule(_ ruleId: String)
-    static func languageCode(for displayName: String) -> String
 }
 
 /// Protocol for custom vocabulary access

--- a/Sources/ContentParsers/MailContentParser.swift
+++ b/Sources/ContentParsers/MailContentParser.swift
@@ -811,7 +811,7 @@ class MailContentParser: ContentParser {
     static func stripQuotedContent(from text: String) -> String {
         let lines = text.components(separatedBy: .newlines)
 
-        // Quote attribution patterns for languages supported by whichlang
+        // Quote attribution patterns for common languages handled by language filtering
         // (Arabic, Dutch, English, French, German, Hindi, Italian, Japanese, Korean,
         // Mandarin, Portuguese, Russian, Spanish, Swedish, Turkish, Vietnamese)
         // Format: "On [date], [name] wrote:" with language-specific variations

--- a/Sources/GrammarBridge/GrammarEngine.swift
+++ b/Sources/GrammarBridge/GrammarEngine.swift
@@ -25,7 +25,7 @@ import Foundation
     ///   - enablePersonNames: Enable recognition of person names (first names)
     ///   - enableLastNames: Enable recognition of surnames/last names
     ///   - enableLanguageDetection: Enable detection and filtering of non-English words
-    ///   - excludedLanguages: Array of language codes to exclude (e.g., ["spanish", "german"])
+    ///   - excludedLanguages: ISO 639-3 language codes to exclude (e.g., ["spa", "deu"])
     ///   - enforceOxfordComma: Enable Oxford comma checking
     ///   - checkEllipsis: Enable ellipsis formatting checking
     ///   - checkUnclosedQuotes: Enable unclosed quotes checking
@@ -96,7 +96,7 @@ import Foundation
     ///   - enablePersonNames: Enable recognition of person names (first names)
     ///   - enableLastNames: Enable recognition of surnames/last names
     ///   - enableLanguageDetection: Enable detection and filtering of non-English words
-    ///   - excludedLanguages: Array of language codes to exclude (e.g., ["spanish", "german"])
+    ///   - excludedLanguages: ISO 639-3 language codes to exclude (e.g., ["spa", "deu"])
     ///   - enforceOxfordComma: Enable Oxford comma checking
     ///   - checkEllipsis: Enable ellipsis formatting checking
     ///   - checkUnclosedQuotes: Enable unclosed quotes checking

--- a/Sources/GrammarBridge/SupportedLanguage.swift
+++ b/Sources/GrammarBridge/SupportedLanguage.swift
@@ -1,0 +1,45 @@
+// SupportedLanguage.swift
+// Detector-backed language metadata shared by preferences and onboarding.
+
+import Foundation
+
+struct SupportedLanguage: Hashable, Identifiable, Sendable {
+    let code: String
+    let englishName: String
+    let nativeName: String
+
+    var id: String {
+        code
+    }
+
+    var secondaryName: String? {
+        nativeName.compare(englishName, options: [.caseInsensitive, .diacriticInsensitive]) == .orderedSame
+            ? nil
+            : nativeName
+    }
+
+    func matches(_ query: String) -> Bool {
+        let normalizedQuery = Self.normalized(query)
+        guard !normalizedQuery.isEmpty else { return true }
+
+        return [code, englishName, nativeName]
+            .map(Self.normalized)
+            .contains { $0.contains(normalizedQuery) }
+    }
+
+    private static func normalized(_ value: String) -> String {
+        value
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+extension GrammarEngine {
+    static let supportedLanguages: [SupportedLanguage] = supported_languages().map { language in
+        SupportedLanguage(
+            code: language.code().toString(),
+            englishName: language.english_name().toString(),
+            nativeName: language.native_name().toString()
+        )
+    }
+}

--- a/Sources/Models/DiagnosticReport.swift
+++ b/Sources/Models/DiagnosticReport.swift
@@ -544,7 +544,9 @@ struct SettingsDump: Codable {
             selectedDialect: preferences.selectedDialect,
             enabledCategories: Array(preferences.enabledCategories).sorted(),
             enableLanguageDetection: preferences.enableLanguageDetection,
-            excludedLanguages: Array(preferences.excludedLanguages).sorted(),
+            excludedLanguages: preferences.excludedLanguages
+                .map(UserPreferences.languageDiagnosticLabel(for:))
+                .sorted(),
             enforceOxfordComma: preferences.enforceOxfordComma,
             checkEllipsis: preferences.checkEllipsis,
             checkUnclosedQuotes: preferences.checkUnclosedQuotes,

--- a/Sources/Models/UserPreferences.swift
+++ b/Sources/Models/UserPreferences.swift
@@ -332,42 +332,50 @@ class UserPreferences: ObservableObject {
         }
     }
 
-    /// Languages to exclude from grammar checking (e.g., "spanish", "german")
+    /// ISO 639-3 language codes to exclude from English grammar checking.
     @Published var excludedLanguages: Set<String> {
         didSet {
             persist(excludedLanguages, forKey: Keys.excludedLanguages)
         }
     }
 
-    /// Available languages for detection (from whichlang library)
-    static let availableLanguages = [
-        "Arabic", "Dutch", "English", "French", "German",
-        "Hindi", "Italian", "Japanese", "Korean", "Mandarin",
-        "Portuguese", "Russian", "Spanish", "Swedish",
-        "Turkish", "Vietnamese",
-    ]
+    /// All non-English languages exposed by the Rust detector.
+    static let availableLanguages = GrammarEngine.supportedLanguages
+        .filter { $0.code != "eng" }
+        .sorted { $0.englishName.localizedCaseInsensitiveCompare($1.englishName) == .orderedAscending }
 
-    /// Map UI-friendly names to language codes for Rust
-    static func languageCode(for name: String) -> String {
-        switch name {
-        case "Arabic": "arabic"
-        case "Dutch": "dutch"
-        case "English": "english"
-        case "French": "french"
-        case "German": "german"
-        case "Hindi": "hindi"
-        case "Italian": "italian"
-        case "Japanese": "japanese"
-        case "Korean": "korean"
-        case "Mandarin": "mandarin"
-        case "Portuguese": "portuguese"
-        case "Russian": "russian"
-        case "Spanish": "spanish"
-        case "Swedish": "swedish"
-        case "Turkish": "turkish"
-        case "Vietnamese": "vietnamese"
-        default: name.lowercased()
+    /// Convert legacy display-name storage to detector-backed ISO codes.
+    static func migratedLanguageCodes(
+        from values: Set<String>,
+        catalog: [SupportedLanguage] = GrammarEngine.supportedLanguages
+    ) -> Set<String> {
+        let codeLookup = Dictionary(uniqueKeysWithValues: catalog.map { ($0.code.lowercased(), $0.code) })
+        var nameLookup: [String: String] = [:]
+
+        for language in catalog {
+            nameLookup[normalizedLanguageLookupKey(language.englishName)] = language.code
+            nameLookup[normalizedLanguageLookupKey(language.nativeName)] = language.code
         }
+
+        return Set(values.compactMap { value in
+            let normalizedCode = value.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+            let code = codeLookup[normalizedCode] ?? nameLookup[normalizedLanguageLookupKey(value)]
+            return code == "eng" ? nil : code
+        })
+    }
+
+    static func languageDisplayName(for code: String) -> String {
+        availableLanguages.first { $0.code == code }?.englishName ?? code.uppercased()
+    }
+
+    static func languageDiagnosticLabel(for code: String) -> String {
+        "\(languageDisplayName(for: code)) (\(code))"
+    }
+
+    private static func normalizedLanguageLookupKey(_ value: String) -> String {
+        value
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     // MARK: - Keyboard Shortcuts
@@ -871,7 +879,19 @@ class UserPreferences: ObservableObject {
         if let data = defaults.data(forKey: Keys.excludedLanguages),
            let set = try? decoder.decode(Set<String>.self, from: data)
         {
-            excludedLanguages = set
+            let migratedCodes = Self.migratedLanguageCodes(from: set)
+            excludedLanguages = migratedCodes
+            if migratedCodes != set {
+                do {
+                    let encoded = try encoder.encode(migratedCodes)
+                    defaults.set(encoded, forKey: Keys.excludedLanguages)
+                } catch {
+                    Logger.warning(
+                        "Failed to migrate excludedLanguages: \(error.localizedDescription)",
+                        category: Logger.general
+                    )
+                }
+            }
         }
 
         // Keyboard Shortcuts

--- a/Sources/UI/LanguageSelectorView.swift
+++ b/Sources/UI/LanguageSelectorView.swift
@@ -1,0 +1,155 @@
+// LanguageSelectorView.swift
+// Shared searchable selector for detector-supported languages.
+
+import SwiftUI
+
+struct LanguageSelectorView: View {
+    @Binding var selectedLanguageCodes: Set<String>
+    let maxHeight: CGFloat
+
+    @State private var searchText = ""
+
+    init(selectedLanguageCodes: Binding<Set<String>>, maxHeight: CGFloat = 260) {
+        _selectedLanguageCodes = selectedLanguageCodes
+        self.maxHeight = maxHeight
+    }
+
+    private var selectedLanguages: [SupportedLanguage] {
+        UserPreferences.availableLanguages.filter { selectedLanguageCodes.contains($0.code) }
+    }
+
+    private var availableLanguages: [SupportedLanguage] {
+        UserPreferences.availableLanguages.filter { !selectedLanguageCodes.contains($0.code) }
+    }
+
+    private var matchingLanguages: [SupportedLanguage] {
+        UserPreferences.availableLanguages.filter { $0.matches(searchText) }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
+
+                TextField("Search by language or code", text: $searchText)
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityLabel("Search languages")
+
+                if !searchText.isEmpty {
+                    Button {
+                        searchText = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Clear search")
+                    .accessibilityLabel("Clear language search")
+                }
+
+                Text("\(selectedLanguageCodes.count) selected")
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .fixedSize()
+                    .accessibilityLabel("\(selectedLanguageCodes.count) languages selected")
+            }
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    if searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        if !selectedLanguages.isEmpty {
+                            languageSection("Selected", languages: selectedLanguages)
+
+                            Divider()
+                                .padding(.vertical, 6)
+                        }
+
+                        languageSection("Available", languages: availableLanguages)
+                    } else if matchingLanguages.isEmpty {
+                        Text("No languages found")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, minHeight: 72)
+                    } else {
+                        languageRows(matchingLanguages)
+                    }
+                }
+                .padding(10)
+            }
+            .frame(maxHeight: maxHeight)
+            .background {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color(nsColor: .controlBackgroundColor))
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(Color.secondary.opacity(0.18), lineWidth: 1)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func languageSection(_ title: String, languages: [SupportedLanguage]) -> some View {
+        if !languages.isEmpty {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 2)
+                .padding(.bottom, 4)
+
+            languageRows(languages)
+        }
+    }
+
+    private func languageRows(_ languages: [SupportedLanguage]) -> some View {
+        ForEach(languages) { language in
+            Toggle(isOn: selectionBinding(for: language.code)) {
+                HStack(spacing: 10) {
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(language.englishName)
+                            .font(.body)
+
+                        if let secondaryName = language.secondaryName {
+                            Text(secondaryName)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    Spacer(minLength: 12)
+
+                    Text(language.code.uppercased())
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.tertiary)
+                }
+                .padding(.vertical, 4)
+                .contentShape(Rectangle())
+            }
+            .toggleStyle(.checkbox)
+            .accessibilityLabel(accessibilityLabel(for: language))
+            .accessibilityHint("Skip English grammar checks in confidently detected passages")
+        }
+    }
+
+    private func selectionBinding(for code: String) -> Binding<Bool> {
+        Binding(
+            get: { selectedLanguageCodes.contains(code) },
+            set: { isSelected in
+                if isSelected {
+                    selectedLanguageCodes.insert(code)
+                } else {
+                    selectedLanguageCodes.remove(code)
+                }
+            }
+        )
+    }
+
+    private func accessibilityLabel(for language: SupportedLanguage) -> String {
+        if let secondaryName = language.secondaryName {
+            return "\(language.englishName), \(secondaryName), \(language.code.uppercased())"
+        }
+        return "\(language.englishName), \(language.code.uppercased())"
+    }
+}

--- a/Sources/UI/LanguageSelectorView.swift
+++ b/Sources/UI/LanguageSelectorView.swift
@@ -4,6 +4,10 @@
 import SwiftUI
 
 struct LanguageSelectorView: View {
+    private static let emptyStateHeight: CGFloat = 64
+    private static let estimatedRowHeight: CGFloat = 46
+    private static let selectedListMaximumRows: CGFloat = 3
+
     @Binding var selectedLanguageCodes: Set<String>
     let maxHeight: CGFloat
 
@@ -22,115 +26,226 @@ struct LanguageSelectorView: View {
         UserPreferences.availableLanguages.filter { !selectedLanguageCodes.contains($0.code) }
     }
 
-    private var matchingLanguages: [SupportedLanguage] {
-        UserPreferences.availableLanguages.filter { $0.matches(searchText) }
+    private var hasSearchQuery: Bool {
+        !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var displayedAvailableLanguages: [SupportedLanguage] {
+        guard hasSearchQuery else { return availableLanguages }
+        return availableLanguages.filter { $0.matches(searchText) }
+    }
+
+    private var selectedListMaximumHeight: CGFloat {
+        min(maxHeight, Self.estimatedRowHeight * Self.selectedListMaximumRows)
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
+            languageList(
+                title: "Selected languages",
+                languages: selectedLanguages,
+                totalCount: selectedLanguages.count,
+                maximumHeight: selectedListMaximumHeight,
+                emptyTitle: "No languages selected yet",
+                emptyDescription: "Choose a language below to add it here.",
+                isSelectedList: true
+            )
+
+            SearchField(text: $searchText, placeholder: "Search available languages by name or code")
+                .frame(maxWidth: .infinity, minHeight: 22, maxHeight: 22)
+                .accessibilityLabel("Search available languages")
+
+            languageList(
+                title: "Available languages",
+                languages: displayedAvailableLanguages,
+                totalCount: availableLanguages.count,
+                maximumHeight: maxHeight,
+                emptyTitle: availableListEmptyTitle,
+                emptyDescription: availableListEmptyDescription,
+                isSelectedList: false
+            )
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var availableListEmptyTitle: String {
+        if availableLanguages.isEmpty {
+            return "All languages are selected"
+        }
+        return "No languages found"
+    }
+
+    private var availableListEmptyDescription: String {
+        if availableLanguages.isEmpty {
+            return "Uncheck a language above to make it available again."
+        }
+        return "Try a different language name or code."
+    }
+
+    private func languageList(
+        title: String,
+        languages: [SupportedLanguage],
+        totalCount: Int,
+        maximumHeight: CGFloat,
+        emptyTitle: String,
+        emptyDescription: String,
+        isSelectedList: Bool
+    ) -> some View {
+        let listHeight = languageListHeight(for: languages, maximumHeight: maximumHeight)
+
+        return VStack(spacing: 0) {
             HStack(spacing: 8) {
-                Image(systemName: "magnifyingglass")
-                    .foregroundStyle(.secondary)
-                    .accessibilityHidden(true)
+                Text(title)
+                    .font(.caption.weight(.semibold))
 
-                TextField("Search by language or code", text: $searchText)
-                    .textFieldStyle(.roundedBorder)
-                    .accessibilityLabel("Search languages")
+                Spacer()
 
-                if !searchText.isEmpty {
-                    Button {
-                        searchText = ""
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .help("Clear search")
-                    .accessibilityLabel("Clear language search")
+                Text(languageCountLabel(
+                    visibleCount: languages.count,
+                    totalCount: totalCount,
+                    isSelectedList: isSelectedList
+                ))
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
+
+                if languageListNeedsScrolling(languages, maximumHeight: maximumHeight) {
+                    Divider()
+                        .frame(height: 12)
+
+                    Label("Scroll to browse", systemImage: "arrow.up.arrow.down")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
 
-                Text("\(selectedLanguageCodes.count) selected")
-                    .font(.caption.monospacedDigit())
-                    .foregroundStyle(.secondary)
-                    .fixedSize()
-                    .accessibilityLabel("\(selectedLanguageCodes.count) languages selected")
+                if isSelectedList, totalCount > 0 {
+                    Divider()
+                        .frame(height: 12)
+
+                    Button("Clear") {
+                        selectedLanguageCodes.removeAll()
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.tint)
+                    .help("Deselect all languages")
+                }
             }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+
+            Divider()
 
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
-                    if searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                        if !selectedLanguages.isEmpty {
-                            languageSection("Selected", languages: selectedLanguages)
-
-                            Divider()
-                                .padding(.vertical, 6)
-                        }
-
-                        languageSection("Available", languages: availableLanguages)
-                    } else if matchingLanguages.isEmpty {
-                        Text("No languages found")
-                            .font(.callout)
-                            .foregroundStyle(.secondary)
-                            .frame(maxWidth: .infinity, minHeight: 72)
+                    if languages.isEmpty {
+                        emptyListState(
+                            title: emptyTitle,
+                            description: emptyDescription,
+                            height: listHeight
+                        )
                     } else {
-                        languageRows(matchingLanguages)
+                        languageRows(languages, isSelectedList: isSelectedList)
                     }
                 }
-                .padding(10)
             }
-            .frame(maxHeight: maxHeight)
-            .background {
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(Color(nsColor: .controlBackgroundColor))
-            }
-            .overlay {
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(Color.secondary.opacity(0.18), lineWidth: 1)
-            }
+            .frame(height: listHeight)
+            .scrollIndicators(.visible)
         }
+        .background {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(Color.secondary.opacity(0.22), lineWidth: 1)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .accessibilityElement(children: .contain)
     }
 
-    @ViewBuilder
-    private func languageSection(_ title: String, languages: [SupportedLanguage]) -> some View {
-        if !languages.isEmpty {
+    private func languageListHeight(
+        for languages: [SupportedLanguage],
+        maximumHeight: CGFloat
+    ) -> CGFloat {
+        guard !languages.isEmpty else { return Self.emptyStateHeight }
+        return min(maximumHeight, CGFloat(languages.count) * Self.estimatedRowHeight)
+    }
+
+    private func languageListNeedsScrolling(
+        _ languages: [SupportedLanguage],
+        maximumHeight: CGFloat
+    ) -> Bool {
+        CGFloat(languages.count) * Self.estimatedRowHeight > maximumHeight
+    }
+
+    private func languageCountLabel(
+        visibleCount: Int,
+        totalCount: Int,
+        isSelectedList: Bool
+    ) -> String {
+        if !isSelectedList, hasSearchQuery, visibleCount != totalCount {
+            return "\(visibleCount) of \(totalCount)"
+        }
+        return isSelectedList ? "\(totalCount) selected" : "\(totalCount) available"
+    }
+
+    private func emptyListState(
+        title: String,
+        description: String,
+        height: CGFloat
+    ) -> some View {
+        VStack(spacing: 2) {
             Text(title)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-                .padding(.horizontal, 2)
-                .padding(.bottom, 4)
+                .font(.callout.weight(.medium))
 
-            languageRows(languages)
+            Text(description)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, minHeight: height)
+    }
+
+    private func languageRows(
+        _ languages: [SupportedLanguage],
+        isSelectedList: Bool
+    ) -> some View {
+        ForEach(languages) { language in
+            languageToggle(language, isSelectedList: isSelectedList)
+
+            Divider()
+                .padding(.leading, 38)
         }
     }
 
-    private func languageRows(_ languages: [SupportedLanguage]) -> some View {
-        ForEach(languages) { language in
-            Toggle(isOn: selectionBinding(for: language.code)) {
-                HStack(spacing: 10) {
-                    VStack(alignment: .leading, spacing: 1) {
-                        Text(language.englishName)
-                            .font(.body)
+    private func languageToggle(
+        _ language: SupportedLanguage,
+        isSelectedList: Bool
+    ) -> some View {
+        Toggle(isOn: selectionBinding(for: language.code)) {
+            HStack(spacing: 10) {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(language.englishName)
+                        .font(.body)
 
-                        if let secondaryName = language.secondaryName {
-                            Text(secondaryName)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
+                    if let secondaryName = language.secondaryName {
+                        Text(secondaryName)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                     }
-
-                    Spacer(minLength: 12)
-
-                    Text(language.code.uppercased())
-                        .font(.caption.monospaced())
-                        .foregroundStyle(.tertiary)
                 }
-                .padding(.vertical, 4)
-                .contentShape(Rectangle())
+
+                Spacer(minLength: 12)
+
+                Text(language.code.uppercased())
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.tertiary)
             }
-            .toggleStyle(.checkbox)
-            .accessibilityLabel(accessibilityLabel(for: language))
-            .accessibilityHint("Skip English grammar checks in confidently detected passages")
+            .contentShape(Rectangle())
         }
+        .toggleStyle(.checkbox)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .accessibilityLabel(accessibilityLabel(for: language))
+        .accessibilityHint(isSelectedList ? "Move to available languages" : "Move to selected languages")
     }
 
     private func selectionBinding(for code: String) -> Binding<Bool> {

--- a/Sources/UI/OnboardingView.swift
+++ b/Sources/UI/OnboardingView.swift
@@ -599,11 +599,11 @@ struct OnboardingView: View {
                         .font(.body)
                         .fontWeight(.semibold)
 
-                    Text("If you write in multiple languages, select them below. TextWarden detects when documents are primarily in another language and skips checking entirely, avoiding false positives on foreign text.")
+                    Text("Select languages that should not receive English grammar checks. TextWarden ignores only passages it detects confidently, so uncertain text remains checked.")
                         .font(.body)
                         .foregroundColor(.secondary)
 
-                    languageSelectionGrid
+                    languageSelector
                 }
 
                 Text("You can change these settings anytime in Settings → Grammar.")
@@ -639,38 +639,13 @@ struct OnboardingView: View {
         }
     }
 
-    @State private var selectedLanguages: Set<String> = []
+    @State private var selectedLanguages: Set<String> = UserPreferences.shared.excludedLanguages
 
-    private var languageSelectionGrid: some View {
-        // All supported languages from UserPreferences.availableLanguages (excluding English)
-        let supportedLanguages = UserPreferences.availableLanguages.filter { $0 != "English" }
-
-        return LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())], spacing: 8) {
-            ForEach(supportedLanguages, id: \.self) { language in
-                Button {
-                    if selectedLanguages.contains(language) {
-                        selectedLanguages.remove(language)
-                    } else {
-                        selectedLanguages.insert(language)
-                    }
-                } label: {
-                    HStack(spacing: 6) {
-                        Image(systemName: selectedLanguages.contains(language) ? "checkmark.circle.fill" : "circle")
-                            .foregroundColor(selectedLanguages.contains(language) ? .accentColor : .secondary)
-                            .font(.subheadline)
-                        Text(language)
-                            .font(.subheadline)
-                            .lineLimit(1)
-                    }
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 8)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(selectedLanguages.contains(language) ? Color.accentColor.opacity(0.1) : Color.secondary.opacity(0.1))
-                    .cornerRadius(6)
-                }
-                .buttonStyle(.plain)
-            }
-        }
+    private var languageSelector: some View {
+        LanguageSelectorView(
+            selectedLanguageCodes: $selectedLanguages,
+            maxHeight: 210
+        )
     }
 
     @State private var websiteToExclude: String = ""
@@ -1065,14 +1040,9 @@ struct OnboardingView: View {
             UserPreferences.shared.selectedDialect = selectedDialect
             Logger.info("Onboarding: Selected dialect: \(selectedDialect)", category: Logger.general)
 
-            // Save language detection settings if any languages selected
-            // Store display names (e.g., "German") directly - conversion to lowercase codes
-            // happens in AnalysisCoordinator when passing to Rust
-            if !selectedLanguages.isEmpty {
-                UserPreferences.shared.enableLanguageDetection = true
-                UserPreferences.shared.excludedLanguages = selectedLanguages
-                Logger.info("Onboarding: Enabled language detection for: \(selectedLanguages)", category: Logger.general)
-            }
+            UserPreferences.shared.excludedLanguages = selectedLanguages
+            UserPreferences.shared.enableLanguageDetection = !selectedLanguages.isEmpty
+            Logger.info("Onboarding: Selected ignored language codes: \(selectedLanguages)", category: Logger.general)
             currentStep = .websiteExclusion
 
         case .websiteExclusion:

--- a/Sources/UI/PreferencesView.swift
+++ b/Sources/UI/PreferencesView.swift
@@ -506,54 +506,22 @@ private struct CustomVocabularyContent: View {
             // MARK: - Language Detection Section
 
             Section {
-                Toggle("Detect non-English text", isOn: $preferences.enableLanguageDetection)
-                    .help("Automatically detect and skip grammar checking for non-English text")
+                Toggle("Ignore selected languages", isOn: $preferences.enableLanguageDetection)
+                    .help("Skip English grammar checks in confidently detected passages")
 
-                Text("Skip grammar checking for documents and sentences in selected languages")
+                Text("Skip English grammar checks in documents and passages confidently detected as a selected language.")
                     .font(.caption)
                     .foregroundColor(.secondary)
 
                 if preferences.enableLanguageDetection {
                     VStack(alignment: .leading, spacing: 8) {
-                        Text("Languages to ignore:")
+                        Text("Languages to ignore")
                             .font(.caption)
                             .foregroundColor(.secondary)
                             .padding(.top, 4)
 
-                        LazyVGrid(columns: [
-                            GridItem(.fixed(150), alignment: .leading),
-                            GridItem(.fixed(150), alignment: .leading),
-                            GridItem(.fixed(150), alignment: .leading),
-                            GridItem(.fixed(150), alignment: .leading),
-                        ], alignment: .leading, spacing: 6) {
-                            ForEach(UserPreferences.availableLanguages.filter { $0 != "English" }.sorted(), id: \.self) { language in
-                                Toggle(language, isOn: Binding(
-                                    get: { preferences.excludedLanguages.contains(language) },
-                                    set: { isSelected in
-                                        if isSelected {
-                                            preferences.excludedLanguages.insert(language)
-                                        } else {
-                                            preferences.excludedLanguages.remove(language)
-                                        }
-                                    }
-                                ))
-                                .toggleStyle(.checkbox)
-                                .font(.system(size: 11))
-                            }
-                        }
-                        .padding(.leading, 20)
-
-                        if !preferences.excludedLanguages.isEmpty {
-                            HStack(spacing: 4) {
-                                Image(systemName: "info.circle")
-                                    .foregroundColor(.blue)
-                                    .font(.caption2)
-                                Text("Words detected as \(preferences.excludedLanguages.sorted().joined(separator: ", ")) will not be marked as errors")
-                                    .font(.caption2)
-                                    .foregroundColor(.secondary)
-                            }
-                            .padding(.top, 4)
-                        }
+                        LanguageSelectorView(selectedLanguageCodes: $preferences.excludedLanguages)
+                            .padding(.leading, 20)
                     }
                 }
             } header: {
@@ -1154,55 +1122,22 @@ struct CustomVocabularyView: View {
             .padding(.bottom, 8)
 
             VStack(alignment: .leading, spacing: 8) {
-                Toggle("Detect non-English text", isOn: $preferences.enableLanguageDetection)
-                    .help("Automatically detect and skip grammar checking for non-English text")
+                Toggle("Ignore selected languages", isOn: $preferences.enableLanguageDetection)
+                    .help("Skip English grammar checks in confidently detected passages")
 
-                Text("Skip grammar checking for documents and sentences in selected languages")
+                Text("Skip English grammar checks in documents and passages confidently detected as a selected language.")
                     .font(.caption)
                     .foregroundColor(.secondary)
 
                 if preferences.enableLanguageDetection {
                     VStack(alignment: .leading, spacing: 8) {
-                        Text("Languages to ignore:")
+                        Text("Languages to ignore")
                             .font(.caption)
                             .foregroundColor(.secondary)
                             .padding(.top, 8)
 
-                        // Language selection grid with fixed columns
-                        LazyVGrid(columns: [
-                            GridItem(.fixed(150), alignment: .leading),
-                            GridItem(.fixed(150), alignment: .leading),
-                            GridItem(.fixed(150), alignment: .leading),
-                            GridItem(.fixed(150), alignment: .leading),
-                        ], alignment: .leading, spacing: 6) {
-                            ForEach(UserPreferences.availableLanguages.filter { $0 != "English" }.sorted(), id: \.self) { language in
-                                Toggle(language, isOn: Binding(
-                                    get: { preferences.excludedLanguages.contains(language) },
-                                    set: { isSelected in
-                                        if isSelected {
-                                            preferences.excludedLanguages.insert(language)
-                                        } else {
-                                            preferences.excludedLanguages.remove(language)
-                                        }
-                                    }
-                                ))
-                                .toggleStyle(.checkbox)
-                                .font(.system(size: 11))
-                            }
-                        }
-                        .padding(.leading, 20)
-
-                        if !preferences.excludedLanguages.isEmpty {
-                            HStack(spacing: 4) {
-                                Image(systemName: "info.circle")
-                                    .foregroundColor(.blue)
-                                    .font(.caption2)
-                                Text("Words detected as \(preferences.excludedLanguages.sorted().joined(separator: ", ")) will not be marked as errors")
-                                    .font(.caption2)
-                                    .foregroundColor(.secondary)
-                            }
-                            .padding(.top, 8)
-                        }
+                        LanguageSelectorView(selectedLanguageCodes: $preferences.excludedLanguages)
+                            .padding(.leading, 20)
                     }
                 }
             }

--- a/Sources/UI/PreferencesView.swift
+++ b/Sources/UI/PreferencesView.swift
@@ -521,7 +521,6 @@ private struct CustomVocabularyContent: View {
                             .padding(.top, 4)
 
                         LanguageSelectorView(selectedLanguageCodes: $preferences.excludedLanguages)
-                            .padding(.leading, 20)
                     }
                 }
             } header: {
@@ -1137,7 +1136,6 @@ struct CustomVocabularyView: View {
                             .padding(.top, 8)
 
                         LanguageSelectorView(selectedLanguageCodes: $preferences.excludedLanguages)
-                            .padding(.leading, 20)
                     }
                 }
             }

--- a/Tests/Contract/GrammarEngineFFITests.swift
+++ b/Tests/Contract/GrammarEngineFFITests.swift
@@ -11,6 +11,17 @@ import XCTest
 final class GrammarEngineFFITests: XCTestCase {
     // MARK: - Basic FFI Contract Tests
 
+    func testSupportedLanguages_ExposesCompleteWhatlangCatalog() throws {
+        let languages = GrammarEngine.supportedLanguages
+
+        XCTAssertEqual(languages.count, 70)
+        XCTAssertEqual(Set(languages.map(\.code)).count, 70)
+
+        let latvian = try XCTUnwrap(languages.first { $0.code == "lav" })
+        XCTAssertEqual(latvian.englishName, "Latvian")
+        XCTAssertEqual(latvian.nativeName, "Latviešu")
+    }
+
     func testAnalyzeText_EmptyString_ReturnsEmptyResult() {
         // Given: Empty text input
         let emptyText = ""

--- a/Tests/Unit/LanguagePreferencesTests.swift
+++ b/Tests/Unit/LanguagePreferencesTests.swift
@@ -1,0 +1,44 @@
+// LanguagePreferencesTests.swift
+
+@testable import TextWarden
+import XCTest
+
+@MainActor
+final class LanguagePreferencesTests: XCTestCase {
+    func testDetectorCatalogContainsAllLanguagesAndExcludesEnglishFromPreferences() {
+        let detectorLanguages = GrammarEngine.supportedLanguages
+        let preferenceLanguages = UserPreferences.availableLanguages
+
+        XCTAssertEqual(detectorLanguages.count, 70)
+        XCTAssertEqual(Set(detectorLanguages.map(\.code)).count, 70)
+        XCTAssertEqual(preferenceLanguages.count, 69)
+        XCTAssertFalse(preferenceLanguages.contains { $0.code == "eng" })
+
+        let latvian = preferenceLanguages.first { $0.code == "lav" }
+        XCTAssertEqual(latvian?.englishName, "Latvian")
+        XCTAssertEqual(latvian?.nativeName, "Latviešu")
+    }
+
+    func testLegacyLanguageNamesMigrateToISO639Codes() {
+        let migrated = UserPreferences.migratedLanguageCodes(
+            from: ["German", "Latviešu", "spa", "English", "Unknown"]
+        )
+
+        XCTAssertEqual(migrated, ["deu", "lav", "spa"])
+    }
+
+    func testLanguageCodeMigrationIsIdempotent() {
+        let codes: Set = ["deu", "lav", "spa"]
+
+        XCTAssertEqual(UserPreferences.migratedLanguageCodes(from: codes), codes)
+    }
+
+    func testLatvianMatchesEnglishNativeAndCodeSearches() throws {
+        let latvian = try XCTUnwrap(UserPreferences.availableLanguages.first { $0.code == "lav" })
+
+        XCTAssertTrue(latvian.matches("Latvian"))
+        XCTAssertTrue(latvian.matches("latviesu"))
+        XCTAssertTrue(latvian.matches("lav"))
+        XCTAssertFalse(latvian.matches("Lithuanian"))
+    }
+}


### PR DESCRIPTION
Replace Whichlang with Whatlang and expose all 69 non-English detector languages. Filtering uses reliable segment detection with Unicode-safe ranges, while Settings and onboarding share the searchable selected/available language picker.

Closes #86

Testing: `make ci-check`