### PR TITLE
chore: remove privacy note from status card

### DIFF
--- a/Sources/Models/RuntimeHealth.swift
+++ b/Sources/Models/RuntimeHealth.swift
@@ -256,10 +256,6 @@ struct RuntimeHealthSnapshot: Equatable {
         }
     }
 
-    var privacyMessage: String {
-        "TextWarden works locally. Your writing is never sent anywhere."
-    }
-
     /// The preference scope a resume action should change.
     /// The runtime reason determines the scope; unrelated pause settings stay untouched.
     var resumeScope: PauseScope? {

--- a/Sources/UI/GeneralPreferencesView.swift
+++ b/Sources/UI/GeneralPreferencesView.swift
@@ -50,10 +50,6 @@ struct GeneralPreferencesView: View {
                             .foregroundColor(.secondary)
                     }
 
-                    Text(snapshot.privacyMessage)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-
                     runtimeHealthAction(for: snapshot)
                 }
             } header: {

--- a/Tests/Unit/RuntimeHealthTests.swift
+++ b/Tests/Unit/RuntimeHealthTests.swift
@@ -16,10 +16,9 @@ final class RuntimeHealthTests: XCTestCase {
         )
     }
 
-    func testRuntimeHealthNeverIncludesWriting() {
+    func testIdleRuntimeHealthHasNoApplicationContext() {
         let snapshot = RuntimeHealthSnapshot.idle
 
-        XCTAssertEqual(snapshot.privacyMessage, "TextWarden works locally. Your writing is never sent anywhere.")
         XCTAssertNil(snapshot.applicationName)
         XCTAssertNil(snapshot.bundleIdentifier)
     }


### PR DESCRIPTION
## Summary

- Remove the redundant privacy note from the General settings status card.
- Remove its unused runtime property and update the related test.

## Testing

- `make run`
- `make ci-check`