### PR TITLE
Fix Markdown link handling

### DIFF
--- a/GrammarEngine/src/analyzer.rs
+++ b/GrammarEngine/src/analyzer.rs
@@ -7,6 +7,7 @@ use crate::slang_dict;
 use harper_core::spell::{MergedDictionary, MutableDictionary};
 use harper_core::{
     linting::{LintGroup, Linter},
+    parsers::MarkdownOptions,
     Dialect, Document,
 };
 use std::sync::{Arc, Mutex};
@@ -699,9 +700,11 @@ pub fn analyze_text(
     // --- PHASE 3: Document Parsing ---
     let parse_start = Instant::now();
 
-    // Parse the text into a Document using our merged dictionary
-    // This ensures abbreviations and slang are recognized during parsing
-    let document = Document::new_plain_english(text, dictionary.as_ref());
+    // Parse Markdown structurally so links and code are not treated as prose.
+    // Keep using the merged dictionary so configured vocabulary is recognized.
+    let mut markdown_options = MarkdownOptions::default();
+    markdown_options.ignore_link_title = true;
+    let document = Document::new_markdown(text, markdown_options, dictionary.as_ref());
     let document_parse_ms = parse_start.elapsed().as_millis() as u64;
 
     // --- PHASE 4: Harper Linting ---
@@ -1206,6 +1209,123 @@ mod tests {
         assert!(result.word_count > 0);
         // Note: Harper may or may not catch this specific error depending on version
         // The test mainly verifies the analyzer runs without crashing
+    }
+
+    #[test]
+    fn test_markdown_link_labels_are_not_linted() {
+        let text = "🙂 I definately decided to use [quickwit-oss/whichlang](https://github.com/quickwit-oss/whichlang) over [greyblake/whatlang-rs](https://github.com/greyblake/whatlang-rs).";
+        let result = analyze_text(
+            text,
+            "American",
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            vec![],
+            true,
+            true,
+            true,
+            true,
+            true,
+        );
+
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|error| error_text(text, error) == "definately"),
+            "errors outside Markdown links must remain"
+        );
+
+        let link_label_ranges = ["quickwit-oss/whichlang", "greyblake/whatlang-rs"].map(|label| {
+            let byte_start = text.find(label).expect("link label must exist");
+            let start = text[..byte_start].chars().count();
+            start..start + label.chars().count()
+        });
+        let errors_in_link_labels = result
+            .errors
+            .iter()
+            .filter(|error| {
+                link_label_ranges
+                    .iter()
+                    .any(|range| error.start < range.end && error.end > range.start)
+            })
+            .map(|error| error_text(text, error))
+            .collect::<Vec<_>>();
+
+        assert!(
+            errors_in_link_labels.is_empty(),
+            "Markdown link labels must not be linted: {errors_in_link_labels:?}"
+        );
+    }
+
+    #[test]
+    fn test_markdown_reference_link_labels_are_not_linted() {
+        let text = "See the [quikcwit project][repository] for details.\n\n[repository]: https://github.com/quickwit-oss/whichlang";
+        let result = analyze_text(
+            text,
+            "American",
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            vec![],
+            true,
+            true,
+            true,
+            true,
+            true,
+        );
+
+        assert!(
+            result
+                .errors
+                .iter()
+                .all(|error| error_text(text, error) != "quikcwit"),
+            "reference-style Markdown link labels must not be linted"
+        );
+    }
+
+    #[test]
+    fn test_malformed_or_escaped_markdown_links_fail_open() {
+        let samples = [
+            r"This uses \[definately](not-a-link) in prose.",
+            "This uses [definately](https://example.com in prose.",
+        ];
+
+        for text in samples {
+            let result = analyze_text(
+                text,
+                "American",
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                vec![],
+                true,
+                true,
+                true,
+                true,
+                true,
+            );
+
+            assert!(
+                result
+                    .errors
+                    .iter()
+                    .any(|error| error_text(text, error) == "definately"),
+                "non-link text must remain lintable: {text}"
+            );
+        }
     }
 
     #[test]

--- a/Sources/UI/PopoverContentViews.swift
+++ b/Sources/UI/PopoverContentViews.swift
@@ -323,6 +323,25 @@ struct SentenceContextView: View {
         return scalars.distance(from: scalarStart, to: scalarEnd)
     }
 
+    static func sentenceEnd(in sourceText: String, startingAt startIndex: String.Index) -> String.Index {
+        var searchIndex = startIndex
+        while searchIndex < sourceText.endIndex {
+            let char = sourceText[searchIndex]
+            if char == "." || char == "!" || char == "?" {
+                let nextIndex = sourceText.index(after: searchIndex)
+                if nextIndex == sourceText.endIndex || sourceText[nextIndex].isWhitespace {
+                    return nextIndex
+                }
+            }
+            if char.isNewline {
+                return searchIndex
+            }
+            searchIndex = sourceText.index(after: searchIndex)
+        }
+
+        return sourceText.endIndex
+    }
+
     /// Extract expected error text from error message (backticks) or suggestions
     private func extractExpectedText(from error: GrammarErrorModel) -> String? {
         // Try to extract from backticks in message (e.g., "Did you mean to spell `staand` this way?")
@@ -529,23 +548,7 @@ struct SentenceContextView: View {
             }
         }
 
-        // Find sentence end by searching forwards for . ! ? or newline (for list items)
-        var sentenceEnd = sourceText.endIndex
-        searchIndex = errorStartIndex
-        while searchIndex < sourceText.endIndex {
-            let char = sourceText[searchIndex]
-            if char == "." || char == "!" || char == "?" {
-                // Include the punctuation in the sentence
-                sentenceEnd = sourceText.index(after: searchIndex)
-                break
-            }
-            // Newline ends sentence for list items
-            if char.isNewline {
-                sentenceEnd = searchIndex
-                break
-            }
-            searchIndex = sourceText.index(after: searchIndex)
-        }
+        let sentenceEnd = Self.sentenceEnd(in: sourceText, startingAt: errorStartIndex)
 
         // sentenceStartOffset is in scalar indices (for arithmetic with error.start/end)
         let sentenceStartScalarOffset = stringIndexToScalarIndex(sentenceStart, in: sourceText)

--- a/Tests/Unit/PopoverSentenceContextTests.swift
+++ b/Tests/Unit/PopoverSentenceContextTests.swift
@@ -1,0 +1,47 @@
+//
+//  PopoverSentenceContextTests.swift
+//  TextWardenTests
+//
+
+@testable import TextWarden
+import XCTest
+
+final class PopoverSentenceContextTests: XCTestCase {
+    func testSentenceEndIgnoresPunctuationInsideMarkdownLinkURLs() throws {
+        let text = "I definately decided to use [quickwit-oss/whichlang](https://github.com/quickwit-oss/whichlang) over [greyblake/whatlang-rs](https://github.com/greyblake/whatlang-rs)."
+        let errorRange = try XCTUnwrap(text.range(of: "definately"))
+
+        let sentenceEnd = SentenceContextView.sentenceEnd(
+            in: text,
+            startingAt: errorRange.lowerBound
+        )
+
+        XCTAssertEqual(String(text[..<sentenceEnd]), text)
+    }
+
+    func testSentenceEndStopsBeforeTheNextSentence() throws {
+        let firstSentence = "A typoo appears before https://github.com/example/repository."
+        let text = "\(firstSentence) Another sentence follows."
+        let errorRange = try XCTUnwrap(text.range(of: "typoo"))
+
+        let sentenceEnd = SentenceContextView.sentenceEnd(
+            in: text,
+            startingAt: errorRange.lowerBound
+        )
+
+        XCTAssertEqual(String(text[..<sentenceEnd]), firstSentence)
+    }
+
+    func testSentenceEndIgnoresQueryPunctuationInsideURLs() throws {
+        let firstSentence = "A typoo points to https://example.com/search?q=all!active."
+        let text = "\(firstSentence) Another sentence follows."
+        let errorRange = try XCTUnwrap(text.range(of: "typoo"))
+
+        let sentenceEnd = SentenceContextView.sentenceEnd(
+            in: text,
+            startingAt: errorRange.lowerBound
+        )
+
+        XCTAssertEqual(String(text[..<sentenceEnd]), firstSentence)
+    }
+}


### PR DESCRIPTION
## Summary

- Ignore valid Markdown link labels during grammar analysis.
- Preserve complete URLs in popover sentence context.

## Testing

- `make ci-check`
- `make run`