### PR TITLE
fix: ignore Print Center

### DIFF
--- a/Sources/AppConfiguration/AppRegistry.swift
+++ b/Sources/AppConfiguration/AppRegistry.swift
@@ -33,6 +33,7 @@ final class AppRegistry {
         "com.apple.AppStore": .ignored,
         "com.apple.finder": .ignored,
         "com.apple.notificationcenterui": .ignored,
+        "com.apple.printcenter": .ignored,
         "com.apple.systempreferences": .ignored,
         "com.apple.UserNotificationCenter": .ignored,
         "com.knollsoft.Rectangle": .ignored,

--- a/Tests/Unit/SafeTrialPromptControllerTests.swift
+++ b/Tests/Unit/SafeTrialPromptControllerTests.swift
@@ -28,6 +28,7 @@ final class SafeTrialPromptControllerTests: XCTestCase {
             "com.apple.AppStore",
             "com.apple.finder",
             "com.apple.notificationcenterui",
+            "com.apple.printcenter",
             "com.apple.systempreferences",
             "com.apple.UserNotificationCenter",
             "com.knollsoft.Rectangle",


### PR DESCRIPTION
## Summary

- treat Print Center as an intentionally ignored non-writing app
- cover its bundle identifier in the built-in policy regression test

## Validation

- make run
- make ci-check