### PR TITLE
fix(ui): keep overlays above monitored apps

### DIFF
--- a/Sources/UI/ErrorOverlayWindow.swift
+++ b/Sources/UI/ErrorOverlayWindow.swift
@@ -854,8 +854,9 @@ class ErrorOverlayWindow: NSPanel {
                 // Reset alpha and mouse tracking state when showing
                 alphaValue = 1.0
                 isMouseInsideOverlay = true
-                // Use order(.above) instead of orderFrontRegardless() to avoid activating the app
-                order(.above, relativeTo: 0)
+                // TextWarden is inactive while the monitored app owns focus, so conditional
+                // ordering can leave the overlay behind that app's windows.
+                orderFrontRegardless()
                 isCurrentlyVisible = true
                 // Start periodic frame validation only for apps that need it (e.g., Outlook Copilot)
                 // This is expensive, so we don't enable it by default
@@ -1162,7 +1163,7 @@ class ErrorOverlayWindow: NSPanel {
         // Show overlay if it wasn't already visible and we have underlines to show
         if !readabilityUnderlines.isEmpty, !isCurrentlyVisible {
             Logger.info("ErrorOverlay: Showing overlay for readability underlines only", category: Logger.ui)
-            order(.above, relativeTo: 0)
+            orderFrontRegardless()
             isCurrentlyVisible = true
             // Start Slack popover detection (only applies to Slack app)
             startSlackPopoverDetection()

--- a/Sources/UI/FloatingErrorIndicator.swift
+++ b/Sources/UI/FloatingErrorIndicator.swift
@@ -754,9 +754,9 @@ class FloatingErrorIndicator: NSPanel {
 
         Logger.debug("FloatingErrorIndicator: Window level: \(level.rawValue), isVisible: \(isVisible)", category: Logger.ui)
         if !isVisible {
-            Logger.debug("FloatingErrorIndicator: Calling order(.above)", category: Logger.ui)
-            order(.above, relativeTo: 0) // Show window without stealing focus
-            Logger.debug("FloatingErrorIndicator: After order(.above), isVisible: \(isVisible)", category: Logger.ui)
+            Logger.debug("FloatingErrorIndicator: Calling orderFrontRegardless()", category: Logger.ui)
+            orderFrontRegardless()
+            Logger.debug("FloatingErrorIndicator: After orderFrontRegardless(), isVisible: \(isVisible)", category: Logger.ui)
         } else {
             Logger.debug("FloatingErrorIndicator: Window already visible", category: Logger.ui)
         }
@@ -826,9 +826,9 @@ class FloatingErrorIndicator: NSPanel {
 
         Logger.debug("FloatingErrorIndicator: Window level: \(level.rawValue), isVisible: \(isVisible)", category: Logger.ui)
         if !isVisible {
-            Logger.debug("FloatingErrorIndicator: Calling order(.above)", category: Logger.ui)
-            order(.above, relativeTo: 0) // Show window without stealing focus
-            Logger.debug("FloatingErrorIndicator: After order(.above), isVisible: \(isVisible)", category: Logger.ui)
+            Logger.debug("FloatingErrorIndicator: Calling orderFrontRegardless()", category: Logger.ui)
+            orderFrontRegardless()
+            Logger.debug("FloatingErrorIndicator: After orderFrontRegardless(), isVisible: \(isVisible)", category: Logger.ui)
         } else {
             Logger.debug("FloatingErrorIndicator: Window already visible", category: Logger.ui)
         }
@@ -984,7 +984,7 @@ class FloatingErrorIndicator: NSPanel {
         positionIndicator(for: element)
 
         if !isVisible {
-            order(.above, relativeTo: 0)
+            orderFrontRegardless()
         }
     }
 


### PR DESCRIPTION
## Summary

- present the underline overlay unconditionally above monitored application windows
- do the same for every floating error indicator presentation path
- preserve the existing non-activating panel and click-through behavior

## Why

AppKit can place windows ordered with `order(.above, relativeTo: 0)` behind the active application when TextWarden itself is inactive. TextWarden then records those windows as visible and does not retry until another focus transition.

## Validation

- `make run`
- Apple Mail recipient-less draft: 4/4 detected errors received valid underlines
- AppKit recorded unconditional front-order operations for both TextWarden windows without the previous non-active-application warning
- CoreGraphics showed both TextWarden windows ahead of the Mail compose window
- `make test`
- `make ci-check`

Context: https://github.com/PhilipSchmid/textwarden/discussions/95