### PR TITLE
fix(mail): support AI Compose selection and insert

### DIFF
--- a/Sources/App/AnalysisCoordinator+StyleChecking.swift
+++ b/Sources/App/AnalysisCoordinator+StyleChecking.swift
@@ -461,6 +461,15 @@ extension AnalysisCoordinator {
     private func selectedText() -> String? {
         guard let element = textMonitor.monitoredElement else { return nil }
 
+        if let context = monitoredContext {
+            let appConfig = appRegistry.effectiveConfiguration(for: context.bundleIdentifier)
+            if appConfig.features.usesWebKitMarkerSelection,
+               let selectedText = MailContentParser.selectedText(in: element)
+            {
+                return selectedText
+            }
+        }
+
         // First check if there's a selection range with non-zero length
         guard let range = AccessibilityBridge.getSelectedTextRange(element),
               range.length > 0
@@ -632,12 +641,30 @@ extension AnalysisCoordinator {
     /// Uses windowed extraction for large documents to keep context manageable
     func extractGenerationContext() -> GenerationContext {
         guard let element = textMonitor.monitoredElement else {
+            textGenerationInsertionTarget = nil
             Logger.debug("AnalysisCoordinator: extractGenerationContext - no monitored element", category: Logger.analysis)
             return .empty
         }
 
+        guard let context = monitoredContext ?? textMonitor.currentContext else {
+            textGenerationInsertionTarget = nil
+            Logger.debug("AnalysisCoordinator: extractGenerationContext - no application context", category: Logger.analysis)
+            return .empty
+        }
+
+        let appConfig = appRegistry.effectiveConfiguration(for: context.bundleIdentifier)
+        let mailSelection = appConfig.features.usesWebKitMarkerSelection
+            ? MailContentParser.selectionSnapshot(in: element)
+            : nil
+
+        textGenerationInsertionTarget = TextGenerationInsertionTarget(
+            element: element,
+            context: context,
+            mailSelection: mailSelection
+        )
+
         // Check for selected text first
-        let selection = selectedText()
+        let selection = mailSelection?.text ?? selectedText()
         if let selected = selection, !selected.isEmpty {
             Logger.debug("AnalysisCoordinator: extractGenerationContext - using selection (\(selected.count) chars)", category: Logger.analysis)
             return GenerationContext(

--- a/Sources/App/AnalysisCoordinator.swift
+++ b/Sources/App/AnalysisCoordinator.swift
@@ -19,6 +19,12 @@ import AppKit
 import Combine
 import Foundation
 
+struct TextGenerationInsertionTarget {
+    let element: AXUIElement
+    let context: ApplicationContext
+    let mailSelection: MailContentParser.SelectionSnapshot?
+}
+
 /// Coordinates grammar analysis workflow: monitoring → analysis → UI
 ///
 /// # Testability
@@ -102,6 +108,10 @@ class AnalysisCoordinator: ObservableObject {
 
     /// Previous text for incremental analysis
     var previousText: String = ""
+
+    /// Editor and exact Mail selection captured before AI Compose takes focus.
+    /// The live text monitor may temporarily clear its element while the panel is open.
+    var textGenerationInsertionTarget: TextGenerationInsertionTarget?
 
     // MARK: - Published State
 
@@ -560,14 +570,20 @@ class AnalysisCoordinator: ObservableObject {
 
         // Handle text insertion from AI Compose
         TextGenerationPopover.shared.onInsertText = { [weak self] text in
-            guard let self,
-                  let element = textMonitor.monitoredElement else { return }
+            guard let self else { return }
+
+            guard let target = textGenerationInsertionTarget else {
+                Logger.warning("AnalysisCoordinator: No captured target for generated text insertion", category: Logger.analysis)
+                return
+            }
+
+            textGenerationInsertionTarget = nil
 
             Logger.debug("AnalysisCoordinator: Inserting generated text (\(text.count) chars)", category: Logger.analysis)
 
             // Use app-specific text replacement strategies
             Task { @MainActor in
-                await self.insertGeneratedTextAsync(text, element: element)
+                await self.insertGeneratedTextAsync(text, target: target)
             }
         }
     }
@@ -575,13 +591,36 @@ class AnalysisCoordinator: ObservableObject {
     /// Insert generated text at cursor or replace selection using app-specific strategies
     /// This reuses the same infrastructure as grammar/style corrections
     @MainActor
-    private func insertGeneratedTextAsync(_ text: String, element: AXUIElement) async {
-        guard let context = monitoredContext else {
-            Logger.warning("AnalysisCoordinator: No context for text insertion", category: Logger.analysis)
+    private func insertGeneratedTextAsync(_ text: String, target: TextGenerationInsertionTarget) async {
+        let element = target.element
+        let context = target.context
+        let appConfig = appRegistry.configuration(for: context.bundleIdentifier)
+
+        if appConfig.features.usesWebKitMarkerSelection,
+           let mailSelection = target.mailSelection
+        {
+            guard MailContentParser.restoreSelection(mailSelection, in: element) else {
+                Logger.warning("AnalysisCoordinator: Generated text insertion aborted because Mail's selection changed", category: Logger.analysis)
+                return
+            }
+
+            lastReplacementTime = Date()
+
+            if let targetApp = NSRunningApplication.runningApplications(withBundleIdentifier: context.bundleIdentifier).first {
+                targetApp.activate()
+            }
+
+            try? await Task.sleep(nanoseconds: UInt64(TimingConstants.shortDelay * 1_000_000_000))
+            typeTextDirectly(text)
+
+            let typingDelay = Double(text.count) * 0.01 + 0.1
+            try? await Task.sleep(nanoseconds: UInt64(typingDelay * 1_000_000_000))
+
+            replacementCompletedAt = Date()
+            scheduleDelayedReanalysis(startTime: Date())
+            Logger.debug("AnalysisCoordinator: Inserted generated text into Mail", category: Logger.analysis)
             return
         }
-
-        let appConfig = appRegistry.configuration(for: context.bundleIdentifier)
 
         // Check app type for strategy selection
         let isElectronApp = context.requiresKeyboardReplacement

--- a/Sources/ContentParsers/MailContentParser.swift
+++ b/Sources/ContentParsers/MailContentParser.swift
@@ -13,6 +13,11 @@ import Foundation
 /// Content parser for Apple Mail
 /// Focuses only on email composition text, ignoring navigation UI
 class MailContentParser: ContentParser {
+    struct SelectionSnapshot {
+        let text: String
+        fileprivate let markerRange: CFTypeRef
+    }
+
     let bundleIdentifier: String = "com.apple.mail"
     let parserName: String = "Apple Mail"
 
@@ -193,6 +198,72 @@ class MailContentParser: ContentParser {
     }
 
     // MARK: - WebKit Text Operations (Bounds, Selection, Replacement)
+
+    /// Read the current selection from Mail's WebKit composition area.
+    /// Mail exposes selection through text markers even when the standard
+    /// AXSelectedTextRange and AXSelectedText attributes are unavailable.
+    static func selectedText(in element: AXUIElement) -> String? {
+        selectionSnapshot(in: element)?.text
+    }
+
+    /// Capture Mail's current WebKit selection so it can be restored after
+    /// TextWarden's AI Compose panel temporarily takes keyboard focus.
+    static func selectionSnapshot(in element: AXUIElement) -> SelectionSnapshot? {
+        var markerRangeRef: CFTypeRef?
+        let markerRangeResult = AXUIElementCopyAttributeValue(
+            element,
+            "AXSelectedTextMarkerRange" as CFString,
+            &markerRangeRef
+        )
+
+        guard markerRangeResult == .success, let markerRange = markerRangeRef else {
+            Logger.debug("MailContentParser: AXSelectedTextMarkerRange unavailable: \(markerRangeResult.rawValue)", category: Logger.accessibility)
+            return nil
+        }
+
+        var selectedTextRef: CFTypeRef?
+        let selectedTextResult = AXUIElementCopyParameterizedAttributeValue(
+            element,
+            "AXStringForTextMarkerRange" as CFString,
+            markerRange,
+            &selectedTextRef
+        )
+
+        guard selectedTextResult == .success,
+              let selectedText = selectedTextRef as? String,
+              !selectedText.isEmpty
+        else {
+            Logger.debug("MailContentParser: AXStringForTextMarkerRange returned no selection: \(selectedTextResult.rawValue)", category: Logger.accessibility)
+            return nil
+        }
+
+        Logger.debug("MailContentParser: Read WebKit selection (\(selectedText.count) chars)", category: Logger.accessibility)
+        return SelectionSnapshot(text: selectedText, markerRange: markerRange)
+    }
+
+    /// Restore and verify a previously captured WebKit selection.
+    /// Verification prevents generated text from being inserted at an
+    /// unrelated caret if Mail changed the document while AI Compose was open.
+    static func restoreSelection(_ snapshot: SelectionSnapshot, in element: AXUIElement) -> Bool {
+        let result = AXUIElementSetAttributeValue(
+            element,
+            "AXSelectedTextMarkerRange" as CFString,
+            snapshot.markerRange
+        )
+
+        guard result == .success else {
+            Logger.warning("MailContentParser: Could not restore WebKit selection: \(result.rawValue)", category: Logger.accessibility)
+            return false
+        }
+
+        guard selectedText(in: element) == snapshot.text else {
+            Logger.warning("MailContentParser: Restored WebKit selection did not match the captured text", category: Logger.accessibility)
+            return false
+        }
+
+        Logger.debug("MailContentParser: Restored and verified WebKit selection", category: Logger.accessibility)
+        return true
+    }
 
     /// Get bounds for a character range in Mail's WebKit composition.
     /// Handles coordinate conversion from layout to screen space when needed.


### PR DESCRIPTION
## Summary

- read selected text from Apple Mail through WebKit text markers
- retain the source editor and exact selection while AI Compose has focus
- restore and verify the selection before inserting generated text

## Validation

- manually verified selected-text Simplify and Insert in Apple Mail
- `make ci-check`