### PR TITLE
fix(mail): recover overlays after AX timing races

### DIFF
--- a/Sources/App/AnalysisCoordinator+TextReplacement.swift
+++ b/Sources/App/AnalysisCoordinator+TextReplacement.swift
@@ -45,6 +45,19 @@ extension AnalysisCoordinator {
             Logger.debug("  [\(i)] \(err.start)-\(err.end): '\(err.message)'", category: Logger.analysis)
         }
 
+        // Capture the canonical source before removing the error. Mail can deliver its AX value
+        // change while keyboard replacement is still completing, so currentSegment may already
+        // contain the corrected text by the time this method runs.
+        let analyzedSourceText = currentErrors.lazy.compactMap { trackedError -> String? in
+            let isExactPositionMatch = trackedError.start == error.start && trackedError.end == error.end
+            let isContentMatch = trackedError.message == error.message
+                && trackedError.lintId == error.lintId
+                && trackedError.category == error.category
+                && (trackedError.end - trackedError.start) == (error.end - error.start)
+            guard isExactPositionMatch || isContentMatch else { return nil }
+            return self.currentErrorSourceStore.sourceText(for: trackedError, among: self.currentErrors)
+        }.first
+
         // Remove the error from currentErrors
         // Primary match on position, fallback on message+lintId+category for exact same error
         let beforeCount = currentErrors.count
@@ -77,20 +90,22 @@ extension AnalysisCoordinator {
         // This is CRITICAL: the underline positions are calculated from currentSegment.content
         // If we don't update it, subsequent errors will have incorrect underline positions
         if let segment = currentSegment {
-            var newContent = segment.content
-            // Use TextIndexConverter to convert Harper's Unicode scalar indices to Swift String.Index
-            // Harper uses Rust char indices (Unicode scalars), but Swift String uses grapheme clusters
-            // Example: "👨‍👩‍👧" is 1 grapheme cluster but 7 Unicode scalars
-            guard let startIdx = TextIndexConverter.scalarIndexToStringIndex(error.start, in: newContent),
-                  let endIdx = TextIndexConverter.scalarIndexToStringIndex(error.end, in: newContent),
-                  startIdx < endIdx
-            else {
-                Logger.warning("removeErrorAndUpdateUI: Invalid range for string replacement (error: \(error.start)-\(error.end), scalar count: \(newContent.unicodeScalars.count))", category: Logger.analysis)
-                return
+            switch ReplacementTextMatcher.reconcileSegment(
+                currentText: segment.content,
+                analyzedText: analyzedSourceText,
+                replacing: error.start ..< error.end,
+                with: suggestion
+            ) {
+            case let .updated(newContent):
+                currentSegment = segment.with(content: newContent)
+                Logger.debug("removeErrorAndUpdateUI: Updated currentSegment content (new length: \(newContent.count))", category: Logger.analysis)
+
+            case .sourceChanged:
+                Logger.debug("removeErrorAndUpdateUI: currentSegment already changed - skipping duplicate mutation", category: Logger.analysis)
+
+            case .invalidRange:
+                Logger.warning("removeErrorAndUpdateUI: Invalid cached range after successful replacement (error: \(error.start)-\(error.end), scalar count: \(segment.content.unicodeScalars.count)); continuing UI cleanup", category: Logger.analysis)
             }
-            newContent.replaceSubrange(startIdx ..< endIdx, with: suggestion)
-            currentSegment = segment.with(content: newContent)
-            Logger.debug("removeErrorAndUpdateUI: Updated currentSegment content (new length: \(newContent.count))", category: Logger.analysis)
         }
 
         // Adjust positions of remaining errors that come after the fixed error

--- a/Sources/App/AnalysisCoordinator.swift
+++ b/Sources/App/AnalysisCoordinator.swift
@@ -3027,6 +3027,20 @@ extension AnalysisCoordinator {
 // MARK: - PositionRefreshDelegate
 
 extension AnalysisCoordinator: PositionRefreshDelegate {
+    /// Re-acquire the focused editor after a replacement-period click.
+    /// A position-only refresh can otherwise keep analyzing the former field.
+    func focusedElementRefreshRequested() {
+        guard !isInReplacementMode else {
+            Logger.debug("AnalysisCoordinator: Replacement still active - skipping focused-element refresh", category: Logger.analysis)
+            return
+        }
+        guard let context = monitoredContext else { return }
+
+        Logger.info("AnalysisCoordinator: Re-acquiring focused editor after replacement", category: Logger.analysis)
+        previousText = ""
+        startMonitoring(context: context)
+    }
+
     /// Called when positions should be recalculated (e.g., after click in Slack)
     func positionRefreshRequested() {
         // Performance profiling for position refresh operations

--- a/Sources/AppConfiguration/BehaviorTypes.swift
+++ b/Sources/AppConfiguration/BehaviorTypes.swift
@@ -213,6 +213,9 @@ enum AppQuirk: Hashable {
     /// App has focus bounce during paste operations
     case focusBouncesDuringPaste
 
+    /// App can expose editable text before its AX range geometry is ready
+    case transientAXGeometry
+
     /// App has text marker index offset (invisible characters)
     case textMarkerIndexOffset
 

--- a/Sources/AppConfiguration/Behaviors/MailBehavior.swift
+++ b/Sources/AppConfiguration/Behaviors/MailBehavior.swift
@@ -56,13 +56,14 @@ struct MailBehavior: AppBehavior {
 
     let timingProfile = TimingProfile(
         analysisDebounce: 0.5,
-        boundsStabilizationDelay: 0.15,
+        boundsStabilizationDelay: 0.25,
         windowChangeGracePeriod: 0.5,
         boundsValidationInterval: 0.3
     )
 
     let knownQuirks: Set<AppQuirk> = [
         .focusBouncesDuringPaste,
+        .transientAXGeometry,
         .requiresBrowserStyleReplacement,
         .requiresFullReanalysisAfterReplacement,
         .usesMailReplaceRangeAPI,

--- a/Sources/Positioning/PositionRefreshCoordinator.swift
+++ b/Sources/Positioning/PositionRefreshCoordinator.swift
@@ -18,6 +18,9 @@ protocol PositionRefreshDelegate: AnyObject {
     /// Called when positions should be recalculated for the current element
     func positionRefreshRequested()
 
+    /// Called when the currently focused editable element must be re-acquired
+    func focusedElementRefreshRequested()
+
     /// Called when underlines should be hidden temporarily (e.g., during scroll)
     func hideUnderlinesRequested()
 }
@@ -41,6 +44,9 @@ class PositionRefreshCoordinator {
 
     /// Debounce work item for click-based refresh
     private var refreshWorkItem: DispatchWorkItem?
+
+    /// Coalesces focus refreshes requested during replacement grace periods
+    private var replacementFocusRefreshTimer: Timer?
 
     /// Debounce work item for scroll-based hide
     private var scrollHideWorkItem: DispatchWorkItem?
@@ -106,6 +112,8 @@ class PositionRefreshCoordinator {
         }
         refreshWorkItem?.cancel()
         refreshWorkItem = nil
+        replacementFocusRefreshTimer?.invalidate()
+        replacementFocusRefreshTimer = nil
         scrollHideWorkItem?.cancel()
         scrollHideWorkItem = nil
         monitoredBundleID = nil
@@ -304,6 +312,10 @@ class PositionRefreshCoordinator {
             // Clicking on a suggestion triggers this, but we don't want to refresh
             // until after the replacement completes and positions are adjusted
             if AnalysisCoordinator.shared.isInReplacementMode {
+                let behavior = AppBehaviorRegistry.shared.behavior(for: bundleID)
+                if behavior.knownQuirks.contains(.focusBouncesDuringPaste) {
+                    scheduleFocusedElementRefreshAfterReplacement()
+                }
                 return
             }
 
@@ -324,6 +336,19 @@ class PositionRefreshCoordinator {
                 deadline: .now() + .milliseconds(Self.refreshDebounceMs(for: bundleID)),
                 execute: workItem
             )
+        }
+    }
+
+    /// Some editors do not emit another usable focus notification when the user changes
+    /// fields during replacement grace. Coalesce those clicks into one later refresh.
+    private func scheduleFocusedElementRefreshAfterReplacement() {
+        replacementFocusRefreshTimer?.invalidate()
+        let delay = TimingConstants.replacementGracePeriod + TimingConstants.mediumDelay
+        replacementFocusRefreshTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
+            guard let self else { return }
+            replacementFocusRefreshTimer = nil
+            Logger.info("PositionRefreshCoordinator: Refreshing focused element after replacement-period click", category: Logger.ui)
+            delegate?.focusedElementRefreshRequested()
         }
     }
 }

--- a/Sources/TextReplacement/Infrastructure/ReplacementTextMatcher.swift
+++ b/Sources/TextReplacement/Infrastructure/ReplacementTextMatcher.swift
@@ -14,6 +14,12 @@ enum ReplacementTextMatcher {
         case unavailable
     }
 
+    enum SegmentReconciliation: Equatable {
+        case updated(String)
+        case sourceChanged
+        case invalidRange
+    }
+
     /// Resolve the live source range without guessing between repeated nearby tokens.
     static func resolveRange(
         in sourceText: String,
@@ -67,6 +73,32 @@ enum ReplacementTextMatcher {
             return .ambiguous(matches)
         }
         return .notFound
+    }
+
+    /// Apply a replacement to cached analysis text only while it still matches the text
+    /// that produced the error. AX notifications may deliver the corrected text first.
+    static func reconcileSegment(
+        currentText: String,
+        analyzedText: String?,
+        replacing range: Range<Int>,
+        with replacement: String
+    ) -> SegmentReconciliation {
+        if let analyzedText, currentText != analyzedText {
+            return .sourceChanged
+        }
+
+        guard range.lowerBound >= 0,
+              range.lowerBound < range.upperBound,
+              range.upperBound <= currentText.unicodeScalars.count,
+              let start = TextIndexConverter.scalarIndexToStringIndex(range.lowerBound, in: currentText),
+              let end = TextIndexConverter.scalarIndexToStringIndex(range.upperBound, in: currentText)
+        else {
+            return .invalidRange
+        }
+
+        var updatedText = currentText
+        updatedText.replaceSubrange(start ..< end, with: replacement)
+        return .updated(updatedText)
     }
 
     private static func text(in range: Range<Int>, from sourceText: String) -> String? {

--- a/Sources/UI/ErrorOverlayWindow.swift
+++ b/Sources/UI/ErrorOverlayWindow.swift
@@ -45,6 +45,9 @@ class ErrorOverlayWindow: NSPanel {
     /// Timer for periodic frame validation (detects resize/scroll during visibility)
     private var frameValidationTimer: Timer?
 
+    /// One-shot recovery for applications that declare transient AX geometry
+    private var geometryRetryTimer: Timer?
+
     /// Timestamp when frame last changed (for stabilization detection)
     private var frameLastChangedAt: Date?
 
@@ -416,10 +419,20 @@ class ErrorOverlayWindow: NSPanel {
     ///   - sourceText: The text that was analyzed (used to detect if text has changed)
     ///   - bypassTypingCheck: If true, skip the typing pause check (used after applying replacements)
     @discardableResult
-    func update(errors: [GrammarErrorModel], element: AXUIElement, context: ApplicationContext?, sourceText _: String? = nil, bypassTypingCheck: Bool = false) -> Int {
+    func update(
+        errors: [GrammarErrorModel],
+        element: AXUIElement,
+        context: ApplicationContext?,
+        sourceText: String? = nil,
+        bypassTypingCheck: Bool = false,
+        allowGeometryRetry: Bool = true
+    ) -> Int {
         // Performance profiling for overlay rebuild operations
         let (profilingState, profilingStartTime) = PerformanceProfiler.shared.beginInterval(.overlayRebuild, context: "errors:\(errors.count)")
         defer { PerformanceProfiler.shared.endInterval(.overlayRebuild, state: profilingState, startTime: profilingStartTime) }
+
+        geometryRetryTimer?.invalidate()
+        geometryRetryTimer = nil
 
         Logger.debug("ErrorOverlay: update() called with \(errors.count) errors", category: Logger.ui)
         self.errors = errors
@@ -428,6 +441,7 @@ class ErrorOverlayWindow: NSPanel {
         // Check if visual underlines are enabled for this app
         let bundleID = context?.bundleIdentifier ?? "unknown"
         currentBundleID = bundleID
+        let appBehavior = AppBehaviorRegistry.shared.behavior(for: bundleID)
 
         // CRITICAL: Check watchdog BEFORE making any AX calls
         // If this app is blocklisted or watchdog is busy, skip ALL AX calls in this function
@@ -889,12 +903,51 @@ class ErrorOverlayWindow: NSPanel {
             }
         }
 
+        // Some editors can expose text before their AX range geometry is ready.
+        // Retry once only when every error failed positioning; other zero-result cases
+        // (preferences, visibility, watchdog, or partial success) must retain their behavior.
+        if allowGeometryRetry,
+           appBehavior.knownQuirks.contains(.transientAXGeometry),
+           !errors.isEmpty,
+           underlines.isEmpty,
+           skippedCount == errors.count,
+           skippedDueToVisibility == 0
+        {
+            let retryDelay = appBehavior.timingProfile.boundsStabilizationDelay
+            Logger.info("ErrorOverlay: Scheduling one AX geometry retry in \(retryDelay)s after \(skippedCount) positioning failures", category: Logger.ui)
+
+            geometryRetryTimer = Timer.scheduledTimer(withTimeInterval: retryDelay, repeats: false) { [weak self] _ in
+                guard let self else { return }
+                geometryRetryTimer = nil
+
+                guard monitoredElement == element,
+                      currentBundleID == bundleID
+                else {
+                    Logger.debug("ErrorOverlay: Skipping stale AX geometry retry", category: Logger.ui)
+                    return
+                }
+
+                Logger.info("ErrorOverlay: Retrying geometry after AX stabilization delay", category: Logger.ui)
+                update(
+                    errors: errors,
+                    element: element,
+                    context: context,
+                    sourceText: sourceText,
+                    bypassTypingCheck: bypassTypingCheck,
+                    allowGeometryRetry: false
+                )
+            }
+        }
+
         return underlines.count
     }
 
     /// Hide overlay
     /// - Parameter preserveLockedHighlight: If true, preserves the locked highlight for re-application after underlines are recreated
     func hide(preserveLockedHighlight: Bool = false) {
+        geometryRetryTimer?.invalidate()
+        geometryRetryTimer = nil
+
         // Performance profiling for overlay hide operations
         let (profilingState, profilingStartTime) = PerformanceProfiler.shared.beginInterval(.overlayHide, context: isCurrentlyVisible ? "visible" : "hidden")
         defer { PerformanceProfiler.shared.endInterval(.overlayHide, state: profilingState, startTime: profilingStartTime) }
@@ -1482,6 +1535,8 @@ class ErrorOverlayWindow: NSPanel {
 
     /// Clean up resources
     deinit {
+        geometryRetryTimer?.invalidate()
+        geometryRetryTimer = nil
         hoverTimer?.invalidate()
         hoverTimer = nil
         stopFrameValidationTimer()

--- a/Tests/Unit/AppBehaviorRegistryTests.swift
+++ b/Tests/Unit/AppBehaviorRegistryTests.swift
@@ -106,6 +106,14 @@ final class AppBehaviorRegistryTests: XCTestCase {
             behavior.knownQuirks.contains(.usesMailReplaceRangeAPI),
             "Mail should use WebKit's AXReplaceRangeWithText API"
         )
+        XCTAssertTrue(
+            behavior.knownQuirks.contains(.focusBouncesDuringPaste),
+            "Mail should refresh focus after replacement-period clicks"
+        )
+        XCTAssertTrue(
+            behavior.knownQuirks.contains(.transientAXGeometry),
+            "Mail should retry transient AX geometry failures"
+        )
     }
 
     func testMailUsesUTF16Indices() {

--- a/Tests/Unit/ReplacementTextMatcherTests.swift
+++ b/Tests/Unit/ReplacementTextMatcherTests.swift
@@ -115,6 +115,42 @@ final class ReplacementTextMatcherTests: XCTestCase {
         XCTAssertEqual(utf16Range.length, 4)
     }
 
+    func testSegmentReconciliationAppliesReplacementToUnchangedAnalysisText() {
+        XCTAssertEqual(
+            ReplacementTextMatcher.reconcileSegment(
+                currentText: "Testing wrong writting",
+                analyzedText: "Testing wrong writting",
+                replacing: 14 ..< 22,
+                with: "writing"
+            ),
+            .updated("Testing wrong writing")
+        )
+    }
+
+    func testSegmentReconciliationPreservesShorterTextAlreadyUpdatedByAX() {
+        XCTAssertEqual(
+            ReplacementTextMatcher.reconcileSegment(
+                currentText: "Testing wrong writing",
+                analyzedText: "Testing wrong writting",
+                replacing: 14 ..< 22,
+                with: "writing"
+            ),
+            .sourceChanged
+        )
+    }
+
+    func testSegmentReconciliationDoesNotDuplicateLongerReplacement() {
+        XCTAssertEqual(
+            ReplacementTextMatcher.reconcileSegment(
+                currentText: "This is better",
+                analyzedText: "This is bad",
+                replacing: 8 ..< 11,
+                with: "better"
+            ),
+            .sourceChanged
+        )
+    }
+
     func testErrorSourceStoreRejectsAnErrorFromAnOlderResultSet() {
         let oldError = capitalizationError(start: 0, end: 4)
         let newError = capitalizationError(start: 0, end: 4)


### PR DESCRIPTION
## Summary

- model Mail timing workarounds as reusable app quirks instead of bundle-specific branches
- retry transient AX geometry once and reacquire focus after replacement clicks
- reconcile replacements when Mail updates AX text first so stale popovers and underlines are cleared
- add regression coverage for Mail behavior and replacement reconciliation

## Testing

- `make run`
- `make test`
- `make ci-check`

Related: https://github.com/PhilipSchmid/textwarden/discussions/95